### PR TITLE
Reorder when the stack id is saved to the configuration bucket

### DIFF
--- a/src/main/java/com/nike/cerberus/operation/cms/CreateCmsClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/cms/CreateCmsClusterOperation.java
@@ -119,6 +119,10 @@ public class CreateCmsClusterOperation implements Operation<CreateCmsClusterComm
         final String stackId = cloudFormationService.createStack(cloudFormationService.getEnvStackName(uniqueStackName),
                 parameters, ConfigConstants.CMS_STACK_TEMPLATE_PATH, true);
 
+        logger.info("Uploading data to the configuration bucket.");
+        configStore.storeStackId(StackName.CMS, stackId);
+        logger.info("Uploading complete.");
+
         final StackStatus endStatus =
                 cloudFormationService.waitForStatus(stackId,
                         Sets.newHashSet(StackStatus.CREATE_COMPLETE, StackStatus.ROLLBACK_COMPLETE));
@@ -129,11 +133,6 @@ public class CreateCmsClusterOperation implements Operation<CreateCmsClusterComm
 
             throw new UnexpectedCloudFormationStatusException(errorMessage);
         }
-
-        logger.info("Uploading data to the configuration bucket.");
-        configStore.storeStackId(StackName.CMS, stackId);
-
-        logger.info("Uploading complete.");
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/operation/consul/CreateConsulClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/consul/CreateConsulClusterOperation.java
@@ -107,6 +107,10 @@ public class CreateConsulClusterOperation implements Operation<CreateConsulClust
         final String stackId = cloudFormationService.createStack(cloudFormationService.getEnvStackName(uniqueStackName),
                 parameters, ConfigConstants.CONSUL_STACK_TEMPLATE_PATH, true);
 
+        logger.info("Uploading data to the configuration bucket.");
+        configStore.storeStackId(StackName.CONSUL, stackId);
+        logger.info("Uploading complete.");
+
         final StackStatus endStatus =
                 cloudFormationService.waitForStatus(stackId,
                         Sets.newHashSet(StackStatus.CREATE_COMPLETE, StackStatus.ROLLBACK_COMPLETE));
@@ -117,11 +121,6 @@ public class CreateConsulClusterOperation implements Operation<CreateConsulClust
 
             throw new UnexpectedCloudFormationStatusException(errorMessage);
         }
-
-        logger.info("Uploading data to the configuration bucket.");
-        configStore.storeStackId(StackName.CONSUL, stackId);
-
-        logger.info("Uploading complete.");
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/operation/gateway/CreateGatewayClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/gateway/CreateGatewayClusterOperation.java
@@ -125,7 +125,9 @@ public class CreateGatewayClusterOperation implements Operation<CreateGatewayClu
         final String stackId = cloudFormationService.createStack(cloudFormationService.getEnvStackName(uniqueStackName),
                 parameters, ConfigConstants.GATEWAY_STACK_TEMPLATE_PATH, true);
 
+        logger.info("Uploading data to the configuration bucket.");
         configStore.storeStackId(StackName.GATEWAY, stackId);
+        logger.info("Uploading complete.");
 
         final StackStatus endStatus =
                 cloudFormationService.waitForStatus(stackId,

--- a/src/main/java/com/nike/cerberus/operation/vault/CreateVaultClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/vault/CreateVaultClusterOperation.java
@@ -123,6 +123,10 @@ public class CreateVaultClusterOperation implements Operation<CreateVaultCluster
         final String stackId = cloudFormationService.createStack(cloudFormationService.getEnvStackName(uniqueStackName),
                 parameters, ConfigConstants.VAULT_STACK_TEMPLATE_PATH, true);
 
+        logger.info("Uploading data to the configuration bucket.");
+        configStore.storeStackId(StackName.VAULT, stackId);
+        logger.info("Uploading complete.");
+
         final StackStatus endStatus =
                 cloudFormationService.waitForStatus(stackId,
                         Sets.newHashSet(StackStatus.CREATE_COMPLETE, StackStatus.ROLLBACK_COMPLETE));
@@ -133,11 +137,6 @@ public class CreateVaultClusterOperation implements Operation<CreateVaultCluster
 
             throw new UnexpectedCloudFormationStatusException(errorMessage);
         }
-
-        logger.info("Uploading data to the configuration bucket.");
-        configStore.storeStackId(StackName.VAULT, stackId);
-
-        logger.info("Uploading complete.");
     }
 
     @Override


### PR DESCRIPTION
Fixing a known issue where if for unforeseen reasons, the CloudFormation stack fails to be created, but we haven't saved the stack id to our configuration bucket yet, leaving us with no reference for the CLI.

These stack operations will now save off the stack id immediately after kicking off the create stack command.