### PR TITLE
Support setting arbitrary configuration properties for CMS

### DIFF
--- a/src/main/java/com/nike/cerberus/command/cms/CreateCmsConfigCommand.java
+++ b/src/main/java/com/nike/cerberus/command/cms/CreateCmsConfigCommand.java
@@ -16,11 +16,15 @@
 
 package com.nike.cerberus.command.cms;
 
+import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.nike.cerberus.command.Command;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.cms.CreateCmsConfigOperation;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.nike.cerberus.command.cms.CreateCmsClusterCommand.COMMAND_NAME;
 
@@ -35,9 +39,15 @@ public class CreateCmsConfigCommand implements Command {
     @Parameter(names = "--admin-group", description = "Group that has admin privileges in CMS.", required = true)
     private String adminGroup;
 
+    @DynamicParameter(names = "-P", description = "Dynamic parameters for setting additional properties in the CMS environment configuration.")
+    private Map<String, String> additionalProperties = new HashMap<>();
 
     public String getAdminGroup() {
         return adminGroup;
+    }
+
+    public Map<String, String> getAdditionalProperties() {
+        return additionalProperties;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/operation/cms/CreateCmsConfigOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/cms/CreateCmsConfigOperation.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Gathers all of the CMS environment configuration and puts it in the configu bucket.
+ * Gathers all of the CMS environment configuration and puts it in the config bucket.
  */
 public class CreateCmsConfigOperation implements Operation<CreateCmsConfigCommand> {
 
@@ -70,12 +70,20 @@ public class CreateCmsConfigOperation implements Operation<CreateCmsConfigComman
         cmsConfigMap.put("vault.addr", String.format("https://%s", cnameToHost(vaultParameters.getCname())));
         cmsConfigMap.put("vault.token", cmsVaultToken.get());
         cmsConfigMap.put("cms.admin.group", command.getAdminGroup());
-        cmsConfigMap.put("cms.jdbc.jdbcUrl", baseOutputs.getCmsDbJdbcConnectionString());
-        cmsConfigMap.put("cms.jdbc.jdbcUser", ConfigConstants.DEFAULT_CMS_DB_NAME);
-        cmsConfigMap.put("cms.jdbc.jdbcPassword", cmsDatabasePassword.get());
         cmsConfigMap.put("root.user.arn", rootUserArn);
         cmsConfigMap.put("admin.role.arn", baseParameters.getAccountAdminArn());
         cmsConfigMap.put("cms.role.arn", baseOutputs.getCmsIamRoleArn());
+        cmsConfigMap.put("JDBC.url", baseOutputs.getCmsDbJdbcConnectionString());
+        cmsConfigMap.put("JDBC.username", ConfigConstants.DEFAULT_CMS_DB_NAME);
+        cmsConfigMap.put("JDBC.password", cmsDatabasePassword.get());
+
+        command.getAdditionalProperties().forEach((k, v) -> {
+            if (!cmsConfigMap.containsKey(k)) {
+                cmsConfigMap.put(k, v);
+            } else {
+                logger.warn("Ignoring additional property that would override system configured property, " + k);
+            }
+        });
 
         configStore.storeCmsEnvConfig(cmsConfigMap);
     }


### PR DESCRIPTION
CMS now requires some additional configuration for whatever auth connector will be used.  Auth connectors require additional properties to be wired correctly at runtime.  These changes to the create-cms-config command allow us to pass in additional configuration that will be added to the environment specific configuration file for CMS.

An additional change was made to support the newer property names for JDBC url, user and password.

If the additional properties attempt to override the system defaults that are set automatically, it will be skipped and a warning message emitted.