### PR TITLE
CMS ELB Healthcheck Target Port Fix

### DIFF
--- a/smaas-cf/smaas/cms-cluster.py
+++ b/smaas-cf/smaas/cms-cluster.py
@@ -148,7 +148,7 @@ load_balancer = template.add_resource(LoadBalancer(
         HealthCheck=HealthCheck(
                 HealthyThreshold=2,
                 Interval=5,
-                Target="HTTP:8077/healthcheck",
+                Target="HTTP:8080/healthcheck",
                 Timeout=2,
                 UnhealthyThreshold=2
         ),


### PR DESCRIPTION
The OSS version of CMS exposes its healthcheck endpoint on 8080, not 8077.  This corrects the CMS ELB configuration to use port 8080.