### PR TITLE
removed ec2-compute-domain-name-suffix param from base command

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 
 group=com.nike
 artifactId=cerberus-lifecycle-cli
-version=1.0.3
+version=1.0.4

--- a/smaas-cf/smaas/support/network.py
+++ b/smaas-cf/smaas/support/network.py
@@ -8,7 +8,6 @@ VPC_SUBNET_CIDRS = {
 
 
 class CerberusNetwork:
-    ec2_domain_name_suffix_param = None
     gateway_cidr_block_param = None
     vpc_cidr_block_param = None
     subnet_cidr_block_param_by_az_map = {}
@@ -17,12 +16,6 @@ class CerberusNetwork:
     subnet_cidr_block_for_az3_output = None
 
     def __init__(self):
-        self.ec2_domain_name_suffix_param = Parameter(
-            "ec2ComputeDomainNameSuffix",
-            Description="The suffix the region will be appended to for the VPC's internal DNS",
-            Type="String"
-        )
-
         self.gateway_cidr_block_param = Parameter(
             "gatewayCidrBlock",
             Description="The internet gateway CIDR block for where traffic is allowed from",
@@ -92,7 +85,6 @@ class CerberusNetwork:
         )
 
     def add_parameters(self, template: Template):
-        template.add_parameter(self.ec2_domain_name_suffix_param)
         template.add_parameter(self.gateway_cidr_block_param)
         template.add_parameter(self.vpc_cidr_block_param)
 

--- a/src/main/java/com/nike/cerberus/command/core/CreateBaseCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/CreateBaseCommand.java
@@ -42,11 +42,6 @@ public class CreateBaseCommand implements Command {
             required = true)
     private String vpcHostedZoneName;
 
-    @Parameter(names = "--ec2-compute-domain-name-suffix",
-            description = "The suffix for the domain names assigned for internal VPC instances.",
-            required = true)
-    private String ec2ComputeDomainNameSuffix;
-
     @Parameter(names = "--owner-email",
             description = "The e-mail for who owns the provisioned resources. Will be tagged on all resources.",
             required = true)
@@ -63,10 +58,6 @@ public class CreateBaseCommand implements Command {
 
     public String getVpcHostedZoneName() {
         return vpcHostedZoneName;
-    }
-
-    public String getEc2ComputeDomainNameSuffix() {
-        return ec2ComputeDomainNameSuffix;
     }
 
     public String getOwnerEmail() {

--- a/src/main/java/com/nike/cerberus/domain/cloudformation/BaseParameters.java
+++ b/src/main/java/com/nike/cerberus/domain/cloudformation/BaseParameters.java
@@ -45,8 +45,6 @@ public class BaseParameters implements TagParameters {
 
     private String vpcHostedZoneName;
 
-    private String ec2ComputeDomainNameSuffix;
-
     @JsonUnwrapped
     private TagParametersDelegate tagParameters = new TagParametersDelegate();
 
@@ -146,15 +144,6 @@ public class BaseParameters implements TagParameters {
 
     public BaseParameters setVpcHostedZoneName(String vpcHostedZoneName) {
         this.vpcHostedZoneName = vpcHostedZoneName;
-        return this;
-    }
-
-    public String getEc2ComputeDomainNameSuffix() {
-        return ec2ComputeDomainNameSuffix;
-    }
-
-    public BaseParameters setEc2ComputeDomainNameSuffix(String ec2ComputeDomainNameSuffix) {
-        this.ec2ComputeDomainNameSuffix = ec2ComputeDomainNameSuffix;
         return this;
     }
 

--- a/src/main/java/com/nike/cerberus/operation/core/CreateBaseOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/CreateBaseOperation.java
@@ -96,8 +96,7 @@ public class CreateBaseOperation implements Operation<CreateBaseCommand> {
                 .setCmsDbMasterUsername(ConfigConstants.DEFAULT_CMS_DB_NAME)
                 .setCmsDbMasterPassword(dbMasterPassword)
                 .setCmsDbName(ConfigConstants.DEFAULT_CMS_DB_NAME)
-                .setVpcHostedZoneName(command.getVpcHostedZoneName())
-                .setEc2ComputeDomainNameSuffix(command.getEc2ComputeDomainNameSuffix());
+                .setVpcHostedZoneName(command.getVpcHostedZoneName());
 
         baseParameters.getTagParameters().setTagEmail(command.getOwnerEmail());
         baseParameters.getTagParameters().setTagName(ConfigConstants.ENV_PREFIX + environmentMetadata.getName());


### PR DESCRIPTION
removed ec2-compute-domain-name-suffix param from base command as it doesn't actually get used by AWS unless you supply custom name servers and we don't supply a hook for allowing custom name servers when configuring the DHCP options for the Cerberus environment VPC.