### PR TITLE
Adds -v flag to the CLI so users can verify the version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,10 @@ tasks.shadowJar.dependsOn createCloudFormation
 tasks.assemble.dependsOn createCloudFormation
 
 shadowJar {
+    def releaseVersion = version
+    doFirst {
+        ant.replace(file: "$buildDir/resources/main/cerberus-lifecycle-cli.properties", token: "@@RELEASE@@", value: releaseVersion)
+    }
     baseName = 'cerberus'
     classifier = null
     version = null

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,22 +1,6 @@
-#
-# Copyright (c) 2016 Nike, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-#Thu Nov 03 10:26:31 PDT 2016
+#Thu Dec 08 10:34:26 PST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,22 @@
-#Thu Dec 08 10:34:26 PST 2016
+#
+# Copyright (c) 2016 Nike, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#Thu Nov 03 10:26:31 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip

--- a/src/main/java/com/nike/cerberus/command/CerberusCommand.java
+++ b/src/main/java/com/nike/cerberus/command/CerberusCommand.java
@@ -39,11 +39,10 @@ public class CerberusCommand {
 
     @Parameter(names = {"--environment", "--env", "-e"},
             description = "Cerberus environment name to execute against.",
-            required = true,
             validateWith = EnvironmentNameValidator.class)
     private String environment;
 
-    @Parameter(names = {"--region", "-r"}, description = "The AWS region to execute against.", required = true)
+    @Parameter(names = {"--region", "-r"}, description = "The AWS region to execute against.")
     private String region;
 
     @Parameter(names = {"--debug"}, description = "Enables debug output.")
@@ -51,6 +50,9 @@ public class CerberusCommand {
 
     @Parameter(names = {"--help", "-h"}, description = "Prints the usage screen for the command.", help = true)
     private boolean help;
+
+    @Parameter(names = {"--version", "-v"}, description = "Prints the version of the CLI.")
+    private boolean version;
 
     @ParametersDelegate
     private ProxyDelegate proxyDelegate = new ProxyDelegate();
@@ -73,6 +75,10 @@ public class CerberusCommand {
 
     public boolean isHelp() {
         return help;
+    }
+
+    public boolean isVersion() {
+        return version;
     }
 
     public ProxyDelegate getProxyDelegate() {

--- a/src/main/resources/cerberus-lifecycle-cli.properties
+++ b/src/main/resources/cerberus-lifecycle-cli.properties
@@ -1,0 +1,1 @@
+cli.version = @@RELEASE@@

--- a/src/test/java/com/nike/cerberus/cli/CerberusRunnerTest.java
+++ b/src/test/java/com/nike/cerberus/cli/CerberusRunnerTest.java
@@ -65,4 +65,32 @@ public class CerberusRunnerTest {
     private void assertContains(String stringToCheck, String expectedContents) {
         assertTrue("did not find expected contents: " + expectedContents, stringToCheck.contains(expectedContents));
     }
+
+    @Test
+    public void testDisplayVersion() {
+
+        // This is a little gross but it does help prove basic start-up works.
+        // It will be a problem if we ever run tests in parallel.
+
+        PrintStream originalOut = System.out;
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            System.setOut(new PrintStream(out));
+
+            // invoke method under test
+            CerberusRunner.main(new String[]{"--version"});
+
+            String output = out.toString();
+
+            // limited validation of help output
+            assertContains(output, "Cerberus Lifecycle CLI");
+
+            // sanity test that output is about expected length
+            assertTrue(output.length() <= 50);
+
+        } finally {
+            // restore System.out
+            System.setOut(originalOut);
+        }
+    }
 }


### PR DESCRIPTION
In reference to Issue #4 I've implemented a -v flag so that users can verify which version of the CLI they are using. 

As -v and --version do not require other parameters the "required" flag had to be removed from environment and region parameters in order for this to properly function. 

Using -v or --version will cause the CLI to ignore any other parameters or commands. 