### PR TITLE
Add version flag and better help messages and re-work region and environment params

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,10 @@ tasks.shadowJar.dependsOn createCloudFormation
 tasks.assemble.dependsOn createCloudFormation
 
 shadowJar {
+    def releaseVersion = version
+    doFirst {
+        ant.replace(file: "$buildDir/resources/main/cerberus-lifecycle-cli.properties", token: "@@RELEASE@@", value: releaseVersion)
+    }
     baseName = 'cerberus'
     classifier = null
     version = null

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 
 group=com.nike
 artifactId=cerberus-lifecycle-cli
-version=0.6.1
+version=0.7.0

--- a/src/main/java/com/nike/cerberus/ConfigConstants.java
+++ b/src/main/java/com/nike/cerberus/ConfigConstants.java
@@ -75,4 +75,6 @@ public class ConfigConstants {
     public static final String CMS_ENV_CONFIG_PATH = "data/cms/environment.properties";
 
     public static final String CF_ELB_IP_SYNC_STACK_TEMPLATE_PATH = "/cloudformation/cloudfront-elb-security-group-updater-lambda.json";
+
+    public static final String VERSION_PROPERTY = "cli.version";
 }

--- a/src/main/java/com/nike/cerberus/command/CerberusCommand.java
+++ b/src/main/java/com/nike/cerberus/command/CerberusCommand.java
@@ -20,6 +20,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.validator.EnvironmentNameValidator;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,11 +39,11 @@ public class CerberusCommand {
     private List<String> parameters = new ArrayList<>();
 
     @Parameter(names = {"--environment", "--env", "-e"},
-            description = "Cerberus environment name to execute against.",
+            description = "Cerberus environment name to execute against. This is required to be set via 'CERBERUS_CLI_ENV' env var or supplied via command arg",
             validateWith = EnvironmentNameValidator.class)
     private String environment;
 
-    @Parameter(names = {"--region", "-r"}, description = "The AWS region to execute against.")
+    @Parameter(names = {"--region", "-r"}, description = "The AWS region to execute against. This is required to be set via 'CERBERUS_CLI_REGION' env var or supplied via command arg")
     private String region;
 
     @Parameter(names = {"--debug"}, description = "Enables debug output.")
@@ -62,11 +63,23 @@ public class CerberusCommand {
     }
 
     public String getEnvironment() {
-        return environment;
+        String calculatedEnv = StringUtils.isNotBlank(environment) ? environment : System.getenv("CERBERUS_CLI_ENV");
+
+        if (StringUtils.isBlank(calculatedEnv)) {
+            throw new IllegalArgumentException("Failed to determine environment, checked 'CERBERUS_CLI_ENV' env var and -e, --env, --environment command options, options must go before the command");
+        }
+
+        return calculatedEnv;
     }
 
     public String getRegion() {
-        return region;
+        String calculatedRegion = StringUtils.isNotBlank(region) ? region : System.getenv("CERBERUS_CLI_REGION");
+
+        if (StringUtils.isBlank(calculatedRegion)) {
+            throw new IllegalArgumentException("Failed to determine environment, checked 'CERBERUS_CLI_REGION' env var and -r, --region command options, options must go before the command");
+        }
+
+        return calculatedRegion;
     }
 
     public boolean isDebug() {

--- a/src/main/java/com/nike/cerberus/command/CerberusCommand.java
+++ b/src/main/java/com/nike/cerberus/command/CerberusCommand.java
@@ -39,11 +39,10 @@ public class CerberusCommand {
 
     @Parameter(names = {"--environment", "--env", "-e"},
             description = "Cerberus environment name to execute against.",
-            required = true,
             validateWith = EnvironmentNameValidator.class)
     private String environment;
 
-    @Parameter(names = {"--region", "-r"}, description = "The AWS region to execute against.", required = true)
+    @Parameter(names = {"--region", "-r"}, description = "The AWS region to execute against.")
     private String region;
 
     @Parameter(names = {"--debug"}, description = "Enables debug output.")
@@ -51,6 +50,9 @@ public class CerberusCommand {
 
     @Parameter(names = {"--help", "-h"}, description = "Prints the usage screen for the command.", help = true)
     private boolean help;
+
+    @Parameter(names = {"--version", "-v"}, description = "Prints the version of the CLI.")
+    private boolean version;
 
     @ParametersDelegate
     private ProxyDelegate proxyDelegate = new ProxyDelegate();
@@ -73,6 +75,10 @@ public class CerberusCommand {
 
     public boolean isHelp() {
         return help;
+    }
+
+    public boolean isVersion() {
+        return version;
     }
 
     public ProxyDelegate getProxyDelegate() {

--- a/src/main/java/com/nike/cerberus/module/PropsModule.java
+++ b/src/main/java/com/nike/cerberus/module/PropsModule.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.module;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PropsModule extends AbstractModule {
+
+    public static final String PROPERTY_FILE = "cerberus-lifecycle-cli.properties";
+
+    @Override
+    protected void configure() {
+        try {
+            InputStream propsStream = this.getClass().getClassLoader().getResourceAsStream(PROPERTY_FILE);
+            Properties properties = new Properties();
+            properties.load(propsStream);
+            Names.bindProperties(binder(), properties);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to bind properties file", e);
+        }
+    }
+}

--- a/src/main/resources/cerberus-lifecycle-cli.properties
+++ b/src/main/resources/cerberus-lifecycle-cli.properties
@@ -1,0 +1,1 @@
+cli.version = @@RELEASE@@

--- a/src/test/java/com/nike/cerberus/cli/CerberusRunnerTest.java
+++ b/src/test/java/com/nike/cerberus/cli/CerberusRunnerTest.java
@@ -65,4 +65,32 @@ public class CerberusRunnerTest {
     private void assertContains(String stringToCheck, String expectedContents) {
         assertTrue("did not find expected contents: " + expectedContents, stringToCheck.contains(expectedContents));
     }
+
+    @Test
+    public void testDisplayVersion() {
+
+        // This is a little gross but it does help prove basic start-up works.
+        // It will be a problem if we ever run tests in parallel.
+
+        PrintStream originalOut = System.out;
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            System.setOut(new PrintStream(out));
+
+            // invoke method under test
+            CerberusRunner.main(new String[]{"--version"});
+
+            String output = out.toString();
+
+            // limited validation of help output
+            assertContains(output, "Cerberus Lifecycle CLI");
+
+            // sanity test that output is about expected length
+            assertTrue(output.length() <= 50);
+
+        } finally {
+            // restore System.out
+            System.setOut(originalOut);
+        }
+    }
 }

--- a/src/test/java/com/nike/cerberus/cli/CerberusRunnerTest.java
+++ b/src/test/java/com/nike/cerberus/cli/CerberusRunnerTest.java
@@ -84,10 +84,6 @@ public class CerberusRunnerTest {
 
             // limited validation of help output
             assertContains(output, "Cerberus Lifecycle CLI");
-
-            // sanity test that output is about expected length
-            assertTrue(output.length() <= 50);
-
         } finally {
             // restore System.out
             System.setOut(originalOut);


### PR DESCRIPTION
- Added @tunderwood's code for version and re-worked the way it loaded props to use Guice so that we can re-use that logic in commands later if needed.
- Re-worked the way region and environment are loaded and verified.
- Re-worked the help messages and error catching to provide a better user experience.

output of -v
![image](https://cloud.githubusercontent.com/assets/711726/21032631/9396a45e-bd5f-11e6-9424-777b18ce684b.png)

old output of typo'ing a command
![image](https://cloud.githubusercontent.com/assets/711726/21032675/d7359684-bd5f-11e6-8a3a-a195f22afa3b.png)

new output
![image](https://cloud.githubusercontent.com/assets/711726/21032684/ebbf3f24-bd5f-11e6-8843-5e780d6608c9.png)

Also now if you forget a commands required option it will just display the commands usage instead of the usage for every command in the cli
![image](https://cloud.githubusercontent.com/assets/711726/21032715/205c8b42-bd60-11e6-8db1-8b20190b65c2.png)
