### PR TITLE
Don't set the TTL, at the vault level, let CMS config control the max…

### DIFF
--- a/src/main/resources/templates/vault.json.mustache
+++ b/src/main/resources/templates/vault.json.mustache
@@ -21,5 +21,4 @@
         }
     },
     "default_lease_ttl": "1h",
-    "max_lease_ttl": "1h"
 }


### PR DESCRIPTION
… ttl, so that its configurable via the CMS config