### PR TITLE
Allow users to specify auto scaling instance counts for cms, consul, gateway, and vault clusters

### DIFF
--- a/smaas-cf/smaas/cms-cluster.py
+++ b/smaas-cf/smaas/cms-cluster.py
@@ -129,6 +129,24 @@ cname_param = template.add_parameter(Parameter(
     Type="String"
 ))
 
+desired_instances_param = template.add_parameter(Parameter(
+    "desiredInstances",
+    Description="Desired Number of Auto Scaling Instances",
+    Type="Number"
+))
+
+maximum_instances_param = template.add_parameter(Parameter(
+    "maximumInstances",
+    Description="Maximum Number of Auto Scaling Instances",
+    Type="Number"
+))
+
+minimum_instances_param = template.add_parameter(Parameter(
+    "minimumInstances",
+    Description="Minimum Number of Auto Scaling Instances",
+    Type="Number"
+))
+
 ###
 #
 # Elastic Load Balancers
@@ -207,15 +225,15 @@ launch_config = template.add_resource(LaunchConfiguration(
 
 autoscaling_group = template.add_resource(AutoScalingGroup(
         "CmsAutoScalingGroup",
-        DesiredCapacity=3,
+        DesiredCapacity=Ref(desired_instances_param),
         HealthCheckGracePeriod=360,
         HealthCheckType="ELB",
         LaunchConfigurationName=Ref(launch_config),
         LoadBalancerNames=[
             Ref(load_balancer)
         ],
-        MaxSize=3,
-        MinSize=3,
+        MaxSize=Ref(maximum_instances_param),
+        MinSize=Ref(minimum_instances_param),
         UpdatePolicy=UpdatePolicy(
             AutoScalingRollingUpdate=AutoScalingRollingUpdate(
                 MaxBatchSize=1,

--- a/smaas-cf/smaas/cms-cluster.py
+++ b/smaas-cf/smaas/cms-cluster.py
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2016 Nike Inc.
+# Copyright (c) 2017 Nike Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smaas-cf/smaas/consul-cluster.py
+++ b/smaas-cf/smaas/consul-cluster.py
@@ -92,6 +92,24 @@ user_data_param = template.add_parameter(Parameter(
         Type="String"
 ))
 
+desired_instances_param = template.add_parameter(Parameter(
+    "desiredInstances",
+    Description="Desired Number of Auto Scaling Instances",
+    Type="Number"
+))
+
+maximum_instances_param = template.add_parameter(Parameter(
+    "maximumInstances",
+    Description="Maximum Number of Auto Scaling Instances",
+    Type="Number"
+))
+
+minimum_instances_param = template.add_parameter(Parameter(
+    "minimumInstances",
+    Description="Minimum Number of Auto Scaling Instances",
+    Type="Number"
+))
+
 subnet_id_refs = []
 for zone_identifier in range(1, 4):
     vpc_subnet_id = template.add_parameter(Parameter(
@@ -127,12 +145,12 @@ consul_launch_config = template.add_resource(LaunchConfiguration(
 
 consul_autoscaling_group = template.add_resource(AutoScalingGroup(
         "ConsulAutoScalingGroup",
-        DesiredCapacity=3,
+        DesiredCapacity=Ref(desired_instances_param),
         HealthCheckGracePeriod=60,
         HealthCheckType="EC2",
         LaunchConfigurationName=Ref(consul_launch_config),
-        MaxSize=3,
-        MinSize=3,
+        MaxSize=Ref(maximum_instances_param),
+        MinSize=Ref(minimum_instances_param),
         UpdatePolicy=UpdatePolicy(
                 AutoScalingRollingUpdate=AutoScalingRollingUpdate(
                         MaxBatchSize=1,

--- a/smaas-cf/smaas/consul-cluster.py
+++ b/smaas-cf/smaas/consul-cluster.py
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2016 Nike Inc.
+# Copyright (c) 2017 Nike Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smaas-cf/smaas/gateway-cluster.py
+++ b/smaas-cf/smaas/gateway-cluster.py
@@ -161,6 +161,24 @@ waf_lambda_key = template.add_parameter(Parameter(
     Description="Key for waf lambda function artifact"
 ))
 
+desired_instances_param = template.add_parameter(Parameter(
+    "desiredInstances",
+    Description="Desired Number of Auto Scaling Instances",
+    Type="Number"
+))
+
+maximum_instances_param = template.add_parameter(Parameter(
+    "maximumInstances",
+    Description="Maximum Number of Auto Scaling Instances",
+    Type="Number"
+))
+
+minimum_instances_param = template.add_parameter(Parameter(
+    "minimumInstances",
+    Description="Minimum Number of Auto Scaling Instances",
+    Type="Number"
+))
+
 ###
 #
 # Elastic Load Balancer
@@ -262,15 +280,15 @@ gateway_launch_config = template.add_resource(LaunchConfiguration(
 
 gateway_autoscaling_group = template.add_resource(AutoScalingGroup(
     "GatewayAutoScalingGroup",
-    DesiredCapacity=3,
+    DesiredCapacity=Ref(desired_instances_param),
     HealthCheckGracePeriod=300,
     HealthCheckType="ELB",
     LaunchConfigurationName=Ref(gateway_launch_config),
     LoadBalancerNames=[
         Ref(gateway_load_balancer)
     ],
-    MaxSize=3,
-    MinSize=3,
+    MaxSize=Ref(maximum_instances_param),
+    MinSize=Ref(minimum_instances_param),
     UpdatePolicy=UpdatePolicy(
         AutoScalingRollingUpdate=AutoScalingRollingUpdate(
             MaxBatchSize=1,

--- a/smaas-cf/smaas/gateway-cluster.py
+++ b/smaas-cf/smaas/gateway-cluster.py
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2016 Nike Inc.
+# Copyright (c) 2017 Nike Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/smaas-cf/smaas/vault-cluster.py
+++ b/smaas-cf/smaas/vault-cluster.py
@@ -147,6 +147,24 @@ cname_param = template.add_parameter(Parameter(
     Type="String"
 ))
 
+desired_instances_param = template.add_parameter(Parameter(
+    "desiredInstances",
+    Description="Desired Number of Auto Scaling Instances",
+    Type="Number"
+))
+
+maximum_instances_param = template.add_parameter(Parameter(
+    "maximumInstances",
+    Description="Maximum Number of Auto Scaling Instances",
+    Type="Number"
+))
+
+minimum_instances_param = template.add_parameter(Parameter(
+    "minimumInstances",
+    Description="Minimum Number of Auto Scaling Instances",
+    Type="Number"
+))
+
 ###
 #
 # Elastic Load Balancer
@@ -251,15 +269,15 @@ vault_launch_config = template.add_resource(LaunchConfiguration(
 
 vault_autoscaling_group = template.add_resource(AutoScalingGroup(
     "VaultAutoScalingGroup",
-    DesiredCapacity=3,
+    DesiredCapacity=Ref(desired_instances_param),
     HealthCheckGracePeriod=60,
     HealthCheckType="EC2",
     LaunchConfigurationName=Ref(vault_launch_config),
     LoadBalancerNames=[
         Ref(vault_load_balancer)
     ],
-    MaxSize=3,
-    MinSize=3,
+    MaxSize=Ref(maximum_instances_param),
+    MinSize=Ref(minimum_instances_param),
     UpdatePolicy=UpdatePolicy(
             AutoScalingRollingUpdate=AutoScalingRollingUpdate(
                     MaxBatchSize=1,

--- a/smaas-cf/smaas/vault-cluster.py
+++ b/smaas-cf/smaas/vault-cluster.py
@@ -1,5 +1,5 @@
 ###
-# Copyright (c) 2016 Nike Inc.
+# Copyright (c) 2017 Nike Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main/java/com/nike/cerberus/command/StackDelegate.java
+++ b/src/main/java/com/nike/cerberus/command/StackDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nike, Inc.
+ * Copyright (c) 2017 Nike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nike/cerberus/command/StackDelegate.java
+++ b/src/main/java/com/nike/cerberus/command/StackDelegate.java
@@ -47,6 +47,15 @@ public class StackDelegate {
             required = true)
     private String costcenter;
 
+    @Parameter(names = "--desired-instances", description = "Desired number of auto scaling instances.")
+    private int desiredInstances = 3;
+
+    @Parameter(names = "--max-instances", description = "Maximum number of auto scaling instances.")
+    private int maximumInstances = 3;
+
+    @Parameter(names = "--min-instances", description = "Minimum number of auto scaling instances")
+    private int minimumInstances = 3;
+
     public String getAmiId() {
         return amiId;
     }
@@ -69,5 +78,17 @@ public class StackDelegate {
 
     public String getCostcenter() {
         return costcenter;
+    }
+
+    public int getDesiredInstances() {
+        return desiredInstances;
+    }
+
+    public int getMaximumInstances() {
+        return maximumInstances;
+    }
+
+    public int getMinimumInstances() {
+        return minimumInstances;
     }
 }

--- a/src/main/java/com/nike/cerberus/command/core/UpdateStackCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/UpdateStackCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nike, Inc.
+ * Copyright (c) 2017 Nike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nike/cerberus/command/core/UpdateStackCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/UpdateStackCommand.java
@@ -66,6 +66,15 @@ public class UpdateStackCommand implements Command {
             description = "Flag for overwriting existing CloudFormation template")
     private boolean overwriteTemplate;
 
+    @Parameter(names = "--desired-instances", description = "Desired number of auto scaling instances.")
+    private Integer desiredInstances;
+
+    @Parameter(names = "--max-instances", description = "Maximum number of auto scaling instances.")
+    private Integer maximumInstances;
+
+    @Parameter(names = "--min-instances", description = "Minimum number of autos scaling instances")
+    private Integer minimumInstances;
+
     @DynamicParameter(names = "-P", description = "Dynamic parameters for overriding the values for specific parameters in the CloudFormation.")
     private Map<String, String> dynamicParameters = new HashMap<>();
 
@@ -103,6 +112,18 @@ public class UpdateStackCommand implements Command {
 
     public Map<String, String> getDynamicParameters() {
         return dynamicParameters;
+    }
+
+    public Integer getDesiredInstances() {
+        return desiredInstances;
+    }
+
+    public Integer getMaximumInstances() {
+        return maximumInstances;
+    }
+
+    public Integer getMinimumInstances() {
+        return minimumInstances;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/domain/cloudformation/LaunchConfigParametersDelegate.java
+++ b/src/main/java/com/nike/cerberus/domain/cloudformation/LaunchConfigParametersDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nike, Inc.
+ * Copyright (c) 2017 Nike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nike/cerberus/domain/cloudformation/LaunchConfigParametersDelegate.java
+++ b/src/main/java/com/nike/cerberus/domain/cloudformation/LaunchConfigParametersDelegate.java
@@ -29,6 +29,12 @@ public class LaunchConfigParametersDelegate {
 
     private String userData;
 
+    private int desiredInstances;
+
+    private int maximumInstances;
+
+    private int minimumInstances;
+
     public String getAmiId() {
         return amiId;
     }
@@ -62,6 +68,33 @@ public class LaunchConfigParametersDelegate {
 
     public LaunchConfigParametersDelegate setUserData(String userData) {
         this.userData = userData;
+        return this;
+    }
+
+    public int getDesiredInstances() {
+        return desiredInstances;
+    }
+
+    public LaunchConfigParametersDelegate setDesiredInstances(int desiredInstances) {
+        this.desiredInstances = desiredInstances;
+        return this;
+    }
+
+    public int getMaximumInstances() {
+        return maximumInstances;
+    }
+
+    public LaunchConfigParametersDelegate setMaximumInstances(int maximumInstances) {
+        this.maximumInstances = maximumInstances;
+        return this;
+    }
+
+    public int getMinimumInstances() {
+        return minimumInstances;
+    }
+
+    public LaunchConfigParametersDelegate setMinimumInstances(int minimumInstances) {
+        this.minimumInstances = minimumInstances;
         return this;
     }
 }

--- a/src/main/java/com/nike/cerberus/operation/cms/CreateCmsClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/cms/CreateCmsClusterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nike, Inc.
+ * Copyright (c) 2017 Nike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nike/cerberus/operation/cms/CreateCmsClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/cms/CreateCmsClusterOperation.java
@@ -108,6 +108,9 @@ public class CreateCmsClusterOperation implements Operation<CreateCmsClusterComm
         cmsParameters.getLaunchConfigParameters().setKeyPairName(command.getStackDelegate().getKeyPairName());
         cmsParameters.getLaunchConfigParameters().setUserData(
                 ec2UserDataService.getUserData(StackName.CMS, command.getStackDelegate().getOwnerGroup()));
+        cmsParameters.getLaunchConfigParameters().setDesiredInstances(command.getStackDelegate().getDesiredInstances());
+        cmsParameters.getLaunchConfigParameters().setMinimumInstances(command.getStackDelegate().getMinimumInstances());
+        cmsParameters.getLaunchConfigParameters().setMaximumInstances(command.getStackDelegate().getMaximumInstances());
 
         cmsParameters.getTagParameters().setTagEmail(command.getStackDelegate().getOwnerEmail());
         cmsParameters.getTagParameters().setTagName(ConfigConstants.ENV_PREFIX + environmentMetadata.getName());

--- a/src/main/java/com/nike/cerberus/operation/consul/CreateConsulClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/consul/CreateConsulClusterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nike, Inc.
+ * Copyright (c) 2017 Nike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nike/cerberus/operation/consul/CreateConsulClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/consul/CreateConsulClusterOperation.java
@@ -97,6 +97,12 @@ public class CreateConsulClusterOperation implements Operation<CreateConsulClust
         consulParameters.getLaunchConfigParameters().setKeyPairName(command.getStackDelegate().getKeyPairName());
         consulParameters.getLaunchConfigParameters().setUserData(
                 ec2UserDataService.getUserData(StackName.CONSUL, command.getStackDelegate().getOwnerGroup()));
+        consulParameters.getLaunchConfigParameters().setDesiredInstances(
+                command.getStackDelegate().getDesiredInstances());
+        consulParameters.getLaunchConfigParameters().setMinimumInstances(
+                command.getStackDelegate().getMinimumInstances());
+        consulParameters.getLaunchConfigParameters().setMaximumInstances(
+                command.getStackDelegate().getMaximumInstances());
 
         consulParameters.getTagParameters().setTagEmail(command.getStackDelegate().getOwnerEmail());
         consulParameters.getTagParameters().setTagName(ConfigConstants.ENV_PREFIX + environmentMetadata.getName());

--- a/src/main/java/com/nike/cerberus/operation/core/UpdateStackOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/UpdateStackOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nike, Inc.
+ * Copyright (c) 2017 Nike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nike/cerberus/operation/core/UpdateStackOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/UpdateStackOperation.java
@@ -185,6 +185,18 @@ public class UpdateStackOperation implements Operation<UpdateStackCommand> {
             launchConfigParameters.getTagParameters().setTagCostcenter(command.getCostcenter());
         }
 
+        if (command.getDesiredInstances() != null) {
+            launchConfigParameters.getLaunchConfigParameters().setDesiredInstances(command.getDesiredInstances());
+        }
+
+        if (command.getMinimumInstances() != null) {
+            launchConfigParameters.getLaunchConfigParameters().setMinimumInstances(command.getMinimumInstances());
+        }
+
+        if (command.getMaximumInstances() != null) {
+            launchConfigParameters.getLaunchConfigParameters().setMaximumInstances(command.getMaximumInstances());
+        }
+
         updateSslConfigParameters(stackName, launchConfigParameters);
 
         final TypeReference<Map<String, String>> typeReference = new TypeReference<Map<String, String>>() {};

--- a/src/main/java/com/nike/cerberus/operation/gateway/CreateGatewayClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/gateway/CreateGatewayClusterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nike, Inc.
+ * Copyright (c) 2017 Nike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nike/cerberus/operation/gateway/CreateGatewayClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/gateway/CreateGatewayClusterOperation.java
@@ -114,6 +114,12 @@ public class CreateGatewayClusterOperation implements Operation<CreateGatewayClu
         gatewayParameters.getLaunchConfigParameters().setKeyPairName(command.getStackDelegate().getKeyPairName());
         gatewayParameters.getLaunchConfigParameters().setUserData(
                 ec2UserDataService.getUserData(StackName.GATEWAY, command.getStackDelegate().getOwnerGroup()));
+        gatewayParameters.getLaunchConfigParameters().setDesiredInstances(
+                command.getStackDelegate().getDesiredInstances());
+        gatewayParameters.getLaunchConfigParameters().setMinimumInstances(
+                command.getStackDelegate().getMinimumInstances());
+        gatewayParameters.getLaunchConfigParameters().setMaximumInstances(
+                command.getStackDelegate().getMaximumInstances());
 
         gatewayParameters.getTagParameters().setTagEmail(command.getStackDelegate().getOwnerEmail());
         gatewayParameters.getTagParameters().setTagName(ConfigConstants.ENV_PREFIX + environmentMetadata.getName());

--- a/src/main/java/com/nike/cerberus/operation/vault/CreateVaultClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/vault/CreateVaultClusterOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nike, Inc.
+ * Copyright (c) 2017 Nike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/nike/cerberus/operation/vault/CreateVaultClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/vault/CreateVaultClusterOperation.java
@@ -112,6 +112,12 @@ public class CreateVaultClusterOperation implements Operation<CreateVaultCluster
         vaultParameters.getLaunchConfigParameters().setKeyPairName(command.getStackDelegate().getKeyPairName());
         vaultParameters.getLaunchConfigParameters().setUserData(
                 ec2UserDataService.getUserData(StackName.VAULT, command.getStackDelegate().getOwnerGroup()));
+        vaultParameters.getLaunchConfigParameters().setDesiredInstances(
+                command.getStackDelegate().getDesiredInstances());
+        vaultParameters.getLaunchConfigParameters().setMinimumInstances(
+                command.getStackDelegate().getMinimumInstances());
+        vaultParameters.getLaunchConfigParameters().setMaximumInstances(
+                command.getStackDelegate().getMaximumInstances());
 
         vaultParameters.getTagParameters().setTagEmail(command.getStackDelegate().getOwnerEmail());
         vaultParameters.getTagParameters().setTagName(ConfigConstants.ENV_PREFIX + environmentMetadata.getName());


### PR DESCRIPTION
Adds CLI parameters for desired, max, and min instances in an auto scaling group.