### PR TITLE
cms and gateway to use cf signals and required policy changes

### DIFF
--- a/smaas-cf/smaas/cms-cluster.py
+++ b/smaas-cf/smaas/cms-cluster.py
@@ -238,7 +238,8 @@ autoscaling_group = template.add_resource(AutoScalingGroup(
             AutoScalingRollingUpdate=AutoScalingRollingUpdate(
                 MaxBatchSize=1,
                 MinInstancesInService=2,
-                PauseTime="PT6M"
+                PauseTime="PT15M",
+                WaitOnResourceSignals=True
             )
         ),
         VPCZoneIdentifier=subnet_id_refs,

--- a/smaas-cf/smaas/gateway-cluster.py
+++ b/smaas-cf/smaas/gateway-cluster.py
@@ -293,7 +293,8 @@ gateway_autoscaling_group = template.add_resource(AutoScalingGroup(
         AutoScalingRollingUpdate=AutoScalingRollingUpdate(
             MaxBatchSize=1,
             MinInstancesInService=2,
-            PauseTime="PT3M"
+            PauseTime="PT15M",
+            WaitOnResourceSignals=True
         )
     ),
     VPCZoneIdentifier=subnet_id_refs,

--- a/smaas-cf/smaas/vpc-and-base.py
+++ b/smaas-cf/smaas/vpc-and-base.py
@@ -554,6 +554,21 @@ gateway_iam_role = template.add_resource(Role(
             "Action": ["sts:AssumeRole"]
         }]
     },
+    Policies=[
+        Policy(
+                PolicyName="gatewayPolicy",
+                PolicyDocument={
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Action": [
+                            "EC2:Describe*",
+                            "cloudformation:SignalResource"
+                        ],
+                        "Resource": "*"
+                    }],
+                }
+        )
+    ],
     Path="/"
 ))
 
@@ -569,6 +584,21 @@ cms_iam_role = template.add_resource(Role(
             "Action": ["sts:AssumeRole"]
         }]
     },
+    Policies=[
+        Policy(
+                PolicyName="cmsPolicy",
+                PolicyDocument={
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Action": [
+                            "EC2:Describe*",
+                            "cloudformation:SignalResource"
+                        ],
+                        "Resource": "*"
+                    }],
+                }
+        )
+    ],
     Path="/"
 ))
 


### PR DESCRIPTION
CMS and Gateway components are enabled to send signals when services are up.
Add IAM policy as well to enable singals