### PR TITLE
Updating example to use min and max of 3 consul instances

### DIFF
--- a/src/main/resources/example-standup.yaml
+++ b/src/main/resources/example-standup.yaml
@@ -52,8 +52,8 @@ consul:
   key-pair-name: example-key
   # optional: desired, min, and max instance values default to 3
   desired-instances: 3
-  max-instances: 4
-  min-instances: 2
+  max-instances: 3
+  min-instances: 3
 
 # Vault-specific parameters
 vault:


### PR DESCRIPTION
People trying out Cerberus may just go with defaults.  Updating example to something we've used.  (We've never even tested min 2 and max 4).

3 or 5 is a good number for number of Consul instances.  