### PR TITLE
Adding --force-overwrite option to create-cms-vault-token

### DIFF
--- a/src/main/java/com/nike/cerberus/command/vault/CreateCmsVaultTokenCommand.java
+++ b/src/main/java/com/nike/cerberus/command/vault/CreateCmsVaultTokenCommand.java
@@ -16,6 +16,7 @@
 
 package com.nike.cerberus.command.vault;
 
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.nike.cerberus.command.Command;
 import com.nike.cerberus.operation.Operation;
@@ -30,6 +31,19 @@ import static com.nike.cerberus.command.vault.CreateCmsVaultTokenCommand.COMMAND
 public class CreateCmsVaultTokenCommand implements Command {
 
     public static final String COMMAND_NAME = "create-cms-vault-token";
+
+    public static final String FORCE_OVERWRITE_LONG_ARG = "--force-overwrite";
+
+    // This option is mainly useful if:
+    // 1) you want to go through some manual steps to rotate the CMS vault token
+    // 2) you've partially hosed a development system
+    @Parameter(names = FORCE_OVERWRITE_LONG_ARG,
+            description = "Force overwriting existing CMS vault token in secrets.json.  It is important to manually revoke the old CMS token when using this option.")
+    private boolean forceOverwrite = false;
+
+    public boolean isForceOverwrite() {
+        return forceOverwrite;
+    }
 
     @Override
     public String getCommandName() {

--- a/src/main/java/com/nike/cerberus/operation/vault/CreateCmsVaultTokenOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/vault/CreateCmsVaultTokenOperation.java
@@ -70,22 +70,37 @@ public class CreateCmsVaultTokenOperation implements Operation<CreateCmsVaultTok
 
     @Override
     public boolean isRunnable(final CreateCmsVaultTokenCommand command) {
+
+        boolean isRunnable = true;
+
         final Optional<String> cmsVaultToken = configStore.getCmsVaultToken();
         final boolean hasVaultInstances = vaultAdminClientFactory.hasVaultInstances();
         final Optional<VaultAdminClient> vaultAdminClient = vaultAdminClientFactory.getClientForLeader();
 
-        if (cmsVaultToken.isPresent()) {
-            logger.error("CMS Vault token is already present.  Use update command to rotate it.");
+        if (command.isForceOverwrite()) {
+            if (cmsVaultToken.isPresent()) {
+                logger.warn("WARNING: Since " + CreateCmsVaultTokenCommand.FORCE_OVERWRITE_LONG_ARG + " was used there may be an old CMS Vault token that needs to be manually revoked in Vault. "
+                        + "The old token can be looked up in the previous version of secrets.json stored in S3 in order to revoke it.");
+            } else {
+                // We don't have to exit here except this probably means someone doesn't understand --force-overwrite
+                logger.error(CreateCmsVaultTokenCommand.FORCE_OVERWRITE_LONG_ARG + " was used but there is no existing CMS Vault token.  Please re-run without " + CreateCmsVaultTokenCommand.FORCE_OVERWRITE_LONG_ARG + " option.");
+                isRunnable = false;
+            }
+        } else if (cmsVaultToken.isPresent()) {
+            logger.error("CMS Vault token is already present.  Use update command to rotate it (or in a non-production system consider using the " + CreateCmsVaultTokenCommand.FORCE_OVERWRITE_LONG_ARG + " option)");
+            isRunnable = false;
         }
 
         if (!hasVaultInstances) {
             logger.error("No vault instances present for this environment!");
+            isRunnable = false;
         }
 
         if (!vaultAdminClient.isPresent()) {
             logger.error("No Vault instance is the current leader!");
+            isRunnable = false;
         }
 
-        return !cmsVaultToken.isPresent() && hasVaultInstances && vaultAdminClient.isPresent();
+        return isRunnable;
     }
 }


### PR DESCRIPTION
Force overwriting existing CMS vault token in secrets.json.  It is important to manually revoke the old CMS token when using this option.