### PR TITLE
Adding update-consul-config command 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 
 group=com.nike
 artifactId=cerberus-lifecycle-cli
-version=0.16.3
+version=0.18.0

--- a/src/main/java/com/nike/cerberus/cli/CerberusRunner.java
+++ b/src/main/java/com/nike/cerberus/cli/CerberusRunner.java
@@ -32,6 +32,7 @@ import com.nike.cerberus.command.cms.CreateCmsConfigCommand;
 import com.nike.cerberus.command.consul.CreateConsulClusterCommand;
 import com.nike.cerberus.command.consul.CreateConsulConfigCommand;
 import com.nike.cerberus.command.consul.CreateVaultAclCommand;
+import com.nike.cerberus.command.consul.UpdateConsulConfigCommand;
 import com.nike.cerberus.command.core.CreateBaseCommand;
 import com.nike.cerberus.command.core.PrintStackInfoCommand;
 import com.nike.cerberus.command.core.RestoreCompleteCerberusDataFromS3BackupCommand;
@@ -169,6 +170,7 @@ public class CerberusRunner {
         registerCommand(new CreateBaseCommand());
         registerCommand(new UploadCertFilesCommand());
         registerCommand(new CreateConsulConfigCommand());
+        registerCommand(new UpdateConsulConfigCommand());
         registerCommand(new CreateVaultAclCommand());
         registerCommand(new CreateConsulClusterCommand());
         registerCommand(new CreateVaultConfigCommand());

--- a/src/main/java/com/nike/cerberus/command/consul/UpdateConsulConfigCommand.java
+++ b/src/main/java/com/nike/cerberus/command/consul/UpdateConsulConfigCommand.java
@@ -1,0 +1,24 @@
+package com.nike.cerberus.command.consul;
+
+import com.beust.jcommander.Parameters;
+import com.nike.cerberus.command.Command;
+import com.nike.cerberus.operation.Operation;
+import com.nike.cerberus.operation.consul.UpdateConsulConfigOperation;
+
+import static com.nike.cerberus.command.consul.CreateConsulConfigCommand.COMMAND_NAME;
+
+@Parameters(commandNames = COMMAND_NAME, commandDescription = "Updates the consul configuration for the cluster while maintaining the secrets in the current config.")
+public class UpdateConsulConfigCommand implements Command {
+
+    public static final String COMMAND_NAME = "update-consul-config";
+
+    @Override
+    public String getCommandName() {
+        return COMMAND_NAME;
+    }
+
+    @Override
+    public Class<? extends Operation<?>> getOperationClass() {
+        return UpdateConsulConfigOperation.class;
+    }
+}

--- a/src/main/java/com/nike/cerberus/generator/ConsulConfigGenerator.java
+++ b/src/main/java/com/nike/cerberus/generator/ConsulConfigGenerator.java
@@ -53,11 +53,21 @@ public class ConsulConfigGenerator {
 
     /**
      * Generates a configuration object that contains the newly generated gossip encryption token,
-     * acl master token and a string representation of the full JSON configuration for Consul.
+     * acl master token, and string representations of the full JSON configuration for Consul.
      */
     public ConsulConfiguration generate(final String datacenter) {
         final String aclMasterToken = uuidSupplier.get();
         final String gossipEncryptionToken = tokenSupplier.get();
+        return generate(datacenter, aclMasterToken, gossipEncryptionToken);
+    }
+
+    /**
+     * Generates a configuration object that contains the supplied gossip encryption token,
+     * acl master token, and string representations of the full JSON configuration for Consul.
+     */
+    public ConsulConfiguration generate(final String datacenter,
+                                        final String aclMasterToken,
+                                        final String gossipEncryptionToken) {
         final ConsulConfigurationInput input = new ConsulConfigurationInput()
                 .setAclMasterToken(aclMasterToken)
                 .setGossipEncryptionToken(gossipEncryptionToken)

--- a/src/main/java/com/nike/cerberus/store/ConfigStore.java
+++ b/src/main/java/com/nike/cerberus/store/ConfigStore.java
@@ -239,6 +239,26 @@ public class ConfigStore {
     }
 
     /**
+     * Retrieves the AclMasterToken for Consul from the config store.
+     */
+    public String getAclMasterToken() {
+        synchronized (secretsDataLock) {
+            final Secrets secrets = getSecretsData();
+            return secrets.getConsul().getAclMasterToken();
+        }
+    }
+
+    /**
+     * Retrieves the GossipEncryptionToken for Consul from the config store.
+     */
+    public String getGossipEncryptionToken() {
+        synchronized (secretsDataLock) {
+            final Secrets secrets = getSecretsData();
+            return secrets.getConsul().getGossipEncryptionToken();
+        }
+    }
+
+    /**
      * Checks if the Vault ACL entry JSON is present in the config store.
      *
      * @return If present


### PR DESCRIPTION
Adding command for that updates the consul configuration for the cluster while maintaining the secrets in the current config.

(FYI: the version of consul configuration currently bundled in CLI is compatible with Consul 0.6.4)