### PR TITLE
Keep the min number of instances in service while updating via CloudFormation

### DIFF
--- a/smaas-cf/smaas/cms-cluster.py
+++ b/smaas-cf/smaas/cms-cluster.py
@@ -132,19 +132,22 @@ cname_param = template.add_parameter(Parameter(
 desired_instances_param = template.add_parameter(Parameter(
     "desiredInstances",
     Description="Desired Number of Auto Scaling Instances",
-    Type="Number"
+    Type="Number",
+    Default="3"
 ))
 
 maximum_instances_param = template.add_parameter(Parameter(
     "maximumInstances",
-    Description="Maximum Number of Auto Scaling Instances",
-    Type="Number"
+    Description="Maximum Number of Auto Scaling Instances (must be larger than min)",
+    Type="Number",
+    Default="4"
 ))
 
 minimum_instances_param = template.add_parameter(Parameter(
     "minimumInstances",
     Description="Minimum Number of Auto Scaling Instances",
-    Type="Number"
+    Type="Number",
+    Default="3"
 ))
 
 ###
@@ -237,7 +240,7 @@ autoscaling_group = template.add_resource(AutoScalingGroup(
         UpdatePolicy=UpdatePolicy(
             AutoScalingRollingUpdate=AutoScalingRollingUpdate(
                 MaxBatchSize=1,
-                MinInstancesInService=2,
+                MinInstancesInService=Ref(minimum_instances_param),
                 PauseTime="PT15M",
                 WaitOnResourceSignals=True
             )

--- a/smaas-cf/smaas/consul-cluster.py
+++ b/smaas-cf/smaas/consul-cluster.py
@@ -95,19 +95,22 @@ user_data_param = template.add_parameter(Parameter(
 desired_instances_param = template.add_parameter(Parameter(
     "desiredInstances",
     Description="Desired Number of Auto Scaling Instances",
-    Type="Number"
+    Type="Number",
+    Default="3"
 ))
 
 maximum_instances_param = template.add_parameter(Parameter(
     "maximumInstances",
-    Description="Maximum Number of Auto Scaling Instances",
-    Type="Number"
+    Description="Maximum Number of Auto Scaling Instances (must be larger than min)",
+    Type="Number",
+    Default="4"
 ))
 
 minimum_instances_param = template.add_parameter(Parameter(
     "minimumInstances",
     Description="Minimum Number of Auto Scaling Instances",
-    Type="Number"
+    Type="Number",
+    Default="3"
 ))
 
 subnet_id_refs = []
@@ -154,7 +157,7 @@ consul_autoscaling_group = template.add_resource(AutoScalingGroup(
         UpdatePolicy=UpdatePolicy(
                 AutoScalingRollingUpdate=AutoScalingRollingUpdate(
                         MaxBatchSize=1,
-                        MinInstancesInService=2,
+                        MinInstancesInService=Ref(minimum_instances_param),
                         PauseTime="PT15M",
                         WaitOnResourceSignals=True
                 )

--- a/smaas-cf/smaas/gateway-cluster.py
+++ b/smaas-cf/smaas/gateway-cluster.py
@@ -164,19 +164,22 @@ waf_lambda_key = template.add_parameter(Parameter(
 desired_instances_param = template.add_parameter(Parameter(
     "desiredInstances",
     Description="Desired Number of Auto Scaling Instances",
-    Type="Number"
+    Type="Number",
+    Default="3"
 ))
 
 maximum_instances_param = template.add_parameter(Parameter(
     "maximumInstances",
-    Description="Maximum Number of Auto Scaling Instances",
-    Type="Number"
+    Description="Maximum Number of Auto Scaling Instances (must be larger than min)",
+    Type="Number",
+    Default="4"
 ))
 
 minimum_instances_param = template.add_parameter(Parameter(
     "minimumInstances",
     Description="Minimum Number of Auto Scaling Instances",
-    Type="Number"
+    Type="Number",
+    Default="3"
 ))
 
 ###
@@ -292,7 +295,7 @@ gateway_autoscaling_group = template.add_resource(AutoScalingGroup(
     UpdatePolicy=UpdatePolicy(
         AutoScalingRollingUpdate=AutoScalingRollingUpdate(
             MaxBatchSize=1,
-            MinInstancesInService=2,
+            MinInstancesInService=Ref(minimum_instances_param),
             PauseTime="PT15M",
             WaitOnResourceSignals=True
         )

--- a/smaas-cf/smaas/vault-cluster.py
+++ b/smaas-cf/smaas/vault-cluster.py
@@ -150,19 +150,22 @@ cname_param = template.add_parameter(Parameter(
 desired_instances_param = template.add_parameter(Parameter(
     "desiredInstances",
     Description="Desired Number of Auto Scaling Instances",
-    Type="Number"
+    Type="Number",
+    Default="3"
 ))
 
 maximum_instances_param = template.add_parameter(Parameter(
     "maximumInstances",
-    Description="Maximum Number of Auto Scaling Instances",
-    Type="Number"
+    Description="Maximum Number of Auto Scaling Instances (must be larger than min)",
+    Type="Number",
+    Default="4"
 ))
 
 minimum_instances_param = template.add_parameter(Parameter(
     "minimumInstances",
     Description="Minimum Number of Auto Scaling Instances",
-    Type="Number"
+    Type="Number",
+    Default="3"
 ))
 
 ###
@@ -281,7 +284,7 @@ vault_autoscaling_group = template.add_resource(AutoScalingGroup(
     UpdatePolicy=UpdatePolicy(
             AutoScalingRollingUpdate=AutoScalingRollingUpdate(
                     MaxBatchSize=1,
-                    MinInstancesInService=2,
+                    MinInstancesInService=Ref(minimum_instances_param),
                     PauseTime="PT15M",
                     WaitOnResourceSignals=True
             )

--- a/src/main/java/com/nike/cerberus/command/StackDelegate.java
+++ b/src/main/java/com/nike/cerberus/command/StackDelegate.java
@@ -60,8 +60,8 @@ public class StackDelegate {
     @Parameter(names = DESIRED_INSTANCES_LONG_ARG, description = "Desired number of auto scaling instances.")
     private int desiredInstances = 3;
 
-    @Parameter(names = MAX_INSTANCES_LONG_ARG, description = "Maximum number of auto scaling instances.")
-    private int maximumInstances = 3;
+    @Parameter(names = MAX_INSTANCES_LONG_ARG, description = "Maximum number of auto scaling instances (must be larger than min).")
+    private int maximumInstances = 4;
 
     @Parameter(names = MIN_INSTANCES_LONG_ARG, description = "Minimum number of auto scaling instances")
     private int minimumInstances = 3;

--- a/src/main/resources/example-standup.yaml
+++ b/src/main/resources/example-standup.yaml
@@ -50,9 +50,9 @@ consul:
   ami-id: ami-1111
   instance-size: m3.medium
   key-pair-name: example-key
-  # optional: desired, min, and max instance values default to 3
+  # optional: desired, min, and max instance values
   desired-instances: 3
-  max-instances: 3
+  max-instances: 4
   min-instances: 3
 
 # Vault-specific parameters
@@ -61,7 +61,7 @@ vault:
   ami-id: ami-2222
   instance-size: m3.medium
   key-pair-name: example-key
-  # optional: desired, min, and max instance values default to 3
+  # optional: desired, min, and max instance values
 
 # Cerberus Management Service-specific parameters
 management-service:
@@ -80,7 +80,7 @@ management-service:
     - auth.connector.onelogin.client_id=123
     - auth.connector.onelogin.client_secret=312
     - auth.connector.onelogin.subdomain=example  # example.onelogin.com ~> 'example'
-  # optional: desired, min, and max instance values default to 3
+  # optional: desired, min, and max instance values
 
 
 gateway:
@@ -88,7 +88,7 @@ gateway:
   ami-id: ami-4444
   instance-size: m3.medium
   key-pair-name: cerberus-test
-  # optional: desired, min, and max instance values default to 3
+  # optional: desired, min, and max instance values
 
 dashboard:
   # The url of the dashboard artifact, probably the newest release on the dashboard Github release page


### PR DESCRIPTION
Updating CloudFormation to keep the min number of instances in service while doing updates (e.g. if you have 3 instances, add a new instance and wait for it to be healthy before removing one of your original 3 instances). This should be a safer way to update Vault and Consul.

This also gives default values in the CloudFormation scripts so that when you update to the new CF the user isn't required to supply values.