### PR TITLE
Adding settings needed for Consul 0.7.x or newer 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 
 group=com.nike
 artifactId=cerberus-lifecycle-cli
-version=0.19.0
+version=0.20.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 
 group=com.nike
 artifactId=cerberus-lifecycle-cli
-version=0.20.0
+version=1.0.0

--- a/src/main/resources/templates/consul-server.json.mustache
+++ b/src/main/resources/templates/consul-server.json.mustache
@@ -18,6 +18,9 @@
     "serf_wan": 8302,
     "server": 8300
   },
+  "performance": {
+    "raft_multiplier": 1
+  },
   "verify_outgoing": true,
   "verify_incoming": true,
   "ca_file": "/etc/consul/ca.pem",

--- a/src/main/resources/templates/consul-server.json.mustache
+++ b/src/main/resources/templates/consul-server.json.mustache
@@ -3,6 +3,7 @@
   "ui_dir": "/var/consul/webui",
   "log_level": "INFO",
   "leave_on_terminate": true,
+  "skip_leave_on_interrupt": false,
   "client_addr": "0.0.0.0",
   "disable_update_check": true,
   "bootstrap_expect": 3,


### PR DESCRIPTION
- Adding performance settings recommended for Consul 0.7.x or newer
- Setting skip_leave_on_interrupt=false to prevent Consul servers from being marked as 'failed' during rolling update (skip_leave_on_interrupt defaults to true for servers 0.7.x or newer)
- These changes are not compatible with Consul 0.6.4.

More here:
https://www.consul.io/docs/upgrade-specific.html
https://www.consul.io/docs/guides/performance.html

Please delay merging this pull request until we have change for default Consul version merged.