### PR TITLE
Changing leave back after finding the related upstart script changes weren't 100% reliable

### DIFF
--- a/src/main/resources/templates/consul-server.json.mustache
+++ b/src/main/resources/templates/consul-server.json.mustache
@@ -2,7 +2,7 @@
   "data_dir": "/var/consul/data",
   "ui_dir": "/var/consul/webui",
   "log_level": "INFO",
-  "leave_on_terminate": false,
+  "leave_on_terminate": true,
   "skip_leave_on_interrupt": true,
   "client_addr": "0.0.0.0",
   "disable_update_check": true,

--- a/src/main/resources/templates/consul-server.json.mustache
+++ b/src/main/resources/templates/consul-server.json.mustache
@@ -3,7 +3,7 @@
   "ui_dir": "/var/consul/webui",
   "log_level": "INFO",
   "leave_on_terminate": true,
-  "skip_leave_on_interrupt": true,
+  "skip_leave_on_interrupt": false,
   "client_addr": "0.0.0.0",
   "disable_update_check": true,
   "bootstrap_expect": 3,


### PR DESCRIPTION
This is related to this change,
https://github.com/Nike-Inc/cerberus-consul-puppet-module/pull/9

The new behavior seemed better at first but after repeated testing I found it wasn't 100% reliable.

It would be good to change these settings back in the future but first, we'd need a new deploy method instead of using CloudFormation for updates.  For example, deploying a new Consul AMI should:
1. Add Consul nodes
2. Wait for them to turn healthy and for the data to be replicated
3. Instruct the old nodes to leave the cluster
4. Wait for them to leave
5. Then shut them down