### PR TITLE
Adding 'acl_enforce_version_8: false' needed before we upgrade Consul to 0.8.x

### DIFF
--- a/src/main/resources/templates/consul-server.json.mustache
+++ b/src/main/resources/templates/consul-server.json.mustache
@@ -31,5 +31,6 @@
   "acl_datacenter": "{{{datacenter}}}",
   "acl_master_token": "{{{aclMasterToken}}}",
   "acl_default_policy": "deny",
-  "acl_down_policy": "deny"
+  "acl_down_policy": "deny",
+  "acl_enforce_version_8": false
 }


### PR DESCRIPTION
For now, if we add this flag, we can upgrade Consul to version 0.8.x easily using the existing access control policies.

In the future, we need to update our policies,
https://www.consul.io/docs/guides/acl.html#complete-acl-coverage-in-consul-0-8