### PR TITLE
Client also needs 'acl_enforce_version_8: false' before we upgrade Consul to 0.8.x

### DIFF
--- a/src/main/resources/templates/consul-client.json.mustache
+++ b/src/main/resources/templates/consul-client.json.mustache
@@ -25,5 +25,6 @@
   "acl_datacenter": "{{{datacenter}}}",
   "acl_master_token": "{{{aclMasterToken}}}",
   "acl_default_policy": "deny",
-  "acl_down_policy": "deny"
+  "acl_down_policy": "deny",
+  "acl_enforce_version_8": false
 }

--- a/src/main/resources/templates/consul-server.json.mustache
+++ b/src/main/resources/templates/consul-server.json.mustache
@@ -31,5 +31,6 @@
   "acl_datacenter": "{{{datacenter}}}",
   "acl_master_token": "{{{aclMasterToken}}}",
   "acl_default_policy": "deny",
-  "acl_down_policy": "deny"
+  "acl_down_policy": "deny",
+  "acl_enforce_version_8": false
 }


### PR DESCRIPTION
This is a follow-on to https://github.com/Nike-Inc/cerberus-lifecycle-cli/pull/43