### PR TITLE
Remove cobertura config

### DIFF
--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,10 +1,4 @@
 {
-    "cobertura": {
-        "net.sourceforge.cobertura:cobertura": {
-            "locked": "2.1.1",
-            "requested": "2.1.1"
-        }
-    },
     "compile": {
         "ch.qos.logback:logback-classic": {
             "locked": "1.1.7",

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -21,7 +21,7 @@ repositories {
 //noinspection GroovyAssignabilityCheck
 dependencies {
     classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:2.2.5'
-    classpath 'net.saliman:gradle-cobertura-plugin:2.2.7'
+    // classpath 'net.saliman:gradle-cobertura-plugin:2.2.7'
     classpath 'com.netflix.nebula:gradle-dependency-lock-plugin:4.2.0'
     classpath "com.github.jengelman.gradle.plugins:shadow:1.2.4"
     classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'

--- a/gradle/check.gradle
+++ b/gradle/check.gradle
@@ -16,7 +16,7 @@
 
 apply plugin: 'findbugs'
 apply plugin: 'pmd'
-apply plugin: 'cobertura'
+// apply plugin: 'cobertura'
 apply plugin: 'com.github.kt3k.coveralls'
 
 findbugs {
@@ -35,15 +35,15 @@ tasks.withType(FindBugs) {
     }
 }
 
-cobertura {
-    // https://github.com/stevesaliman/gradle-cobertura-plugin/blob/master/usage.md
-    coverageReportDir = new File("$buildDir/reports/cobertura")
-    coverageFormats = ['html', 'xml']
-    coverageIgnoreTrivial = true
-    coverageExcludes = [
-    ]
-}
-test.finalizedBy(project.tasks.coberturaReport)
+// cobertura {
+//     // https://github.com/stevesaliman/gradle-cobertura-plugin/blob/master/usage.md
+//     coverageReportDir = new File("$buildDir/reports/cobertura")
+//     coverageFormats = ['html', 'xml']
+//     coverageIgnoreTrivial = true
+//     coverageExcludes = [
+//     ]
+// }
+// test.finalizedBy(project.tasks.coberturaReport)
 
 task findbugsHtml {
     group = "Verification"


### PR DESCRIPTION
Fix gradle build errors with Cobertura by removing its config.