### PR TITLE
Feature: Validate AMI tag before creating or deploying a component

### DIFF
--- a/src/main/java/com/nike/cerberus/ConfigConstants.java
+++ b/src/main/java/com/nike/cerberus/ConfigConstants.java
@@ -107,4 +107,14 @@ public class ConfigConstants {
             JDBC_URL_KEY,
             JDBC_USERNAME_KEY,
             JDBC_PASSWORD_KEY);
+
+    public static final String CERBERUS_AMI_TAG_NAME = "tag:cerberus_component";
+
+    public static final String CMS_AMI_TAG_VALUE = "cms";
+
+    public static final String GATEWAY_AMI_TAG_VALUE = "gateway";
+
+    public static final String CONSUL_AMI_TAG_VALUE = "consul";
+
+    public static final String VAULT_AMI_TAG_VALUE = "vault";
 }

--- a/src/main/java/com/nike/cerberus/ConfigConstants.java
+++ b/src/main/java/com/nike/cerberus/ConfigConstants.java
@@ -117,4 +117,15 @@ public class ConfigConstants {
     public static final String CONSUL_AMI_TAG_VALUE = "consul";
 
     public static final String VAULT_AMI_TAG_VALUE = "vault";
+
+    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
+
+    public static final String SKIP_AMI_TAG_CHECK_DESCRIPTION = "Skip validation of 'cerberus_component' tag on AMI";
+
+    public static final String AMI_TAG_CHECK_ERROR_MESSAGE
+                        = "FAIL: AMI tag check failed!\n"
+                        + "Given AMI ID either does not exist "
+                        + "or does not contain cerberus tag 'cerberus_component' with stack name "
+                        + "or cerberus tag does not match the stack that is being deployed.\n"
+                        + "Please refer documentation on AMI Tagging or use '"+ SKIP_AMI_TAG_CHECK_ARG +"' option to skip this check.";
 }

--- a/src/main/java/com/nike/cerberus/command/cms/CreateCmsClusterCommand.java
+++ b/src/main/java/com/nike/cerberus/command/cms/CreateCmsClusterCommand.java
@@ -25,6 +25,8 @@ import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.cms.CreateCmsClusterOperation;
 
 import static com.nike.cerberus.command.cms.CreateCmsClusterCommand.COMMAND_NAME;
+import static com.nike.cerberus.ConfigConstants.SKIP_AMI_TAG_CHECK_ARG;
+import static com.nike.cerberus.ConfigConstants.SKIP_AMI_TAG_CHECK_DESCRIPTION;
 
 /**
  * Command to create the CMS cluster.
@@ -33,8 +35,6 @@ import static com.nike.cerberus.command.cms.CreateCmsClusterCommand.COMMAND_NAME
 public class CreateCmsClusterCommand implements Command {
 
     public static final String COMMAND_NAME = "create-cms-cluster";
-
-    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
 
     @ParametersDelegate
     private StackDelegate stackDelegate = new StackDelegate();
@@ -49,7 +49,7 @@ public class CreateCmsClusterCommand implements Command {
     }
 
     @Parameter(names = SKIP_AMI_TAG_CHECK_ARG,
-            description = "Flag for skipping validation of AMI with matching stackname tags")
+            description = SKIP_AMI_TAG_CHECK_DESCRIPTION)
     private boolean skipAmiTagCheck;
 
     public boolean isSkipAmiTagCheck() {

--- a/src/main/java/com/nike/cerberus/command/cms/CreateCmsClusterCommand.java
+++ b/src/main/java/com/nike/cerberus/command/cms/CreateCmsClusterCommand.java
@@ -16,6 +16,7 @@
 
 package com.nike.cerberus.command.cms;
 
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
@@ -33,6 +34,8 @@ public class CreateCmsClusterCommand implements Command {
 
     public static final String COMMAND_NAME = "create-cms-cluster";
 
+    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
+
     @ParametersDelegate
     private StackDelegate stackDelegate = new StackDelegate();
 
@@ -43,6 +46,14 @@ public class CreateCmsClusterCommand implements Command {
     @Override
     public String getCommandName() {
         return COMMAND_NAME;
+    }
+
+    @Parameter(names = SKIP_AMI_TAG_CHECK_ARG,
+            description = "Flag for skipping validation of AMI with matching stackname tags")
+    private boolean skipAmiTagCheck;
+
+    public boolean isSkipAmiTagCheck() {
+        return skipAmiTagCheck;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/command/consul/CreateConsulClusterCommand.java
+++ b/src/main/java/com/nike/cerberus/command/consul/CreateConsulClusterCommand.java
@@ -16,6 +16,7 @@
 
 package com.nike.cerberus.command.consul;
 
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
@@ -33,6 +34,8 @@ public class CreateConsulClusterCommand implements Command {
 
     public static final String COMMAND_NAME = "create-consul-cluster";
 
+    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
+
     @ParametersDelegate
     private StackDelegate stackDelegate = new StackDelegate();
 
@@ -43,6 +46,14 @@ public class CreateConsulClusterCommand implements Command {
     @Override
     public String getCommandName() {
         return COMMAND_NAME;
+    }
+
+    @Parameter(names = SKIP_AMI_TAG_CHECK_ARG,
+            description = "Flag for skipping validation of AMI with matching stackname tags")
+    private boolean skipAmiTagCheck;
+
+    public boolean isSkipAmiTagCheck() {
+        return skipAmiTagCheck;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/command/consul/CreateConsulClusterCommand.java
+++ b/src/main/java/com/nike/cerberus/command/consul/CreateConsulClusterCommand.java
@@ -25,6 +25,8 @@ import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.consul.CreateConsulClusterOperation;
 
 import static com.nike.cerberus.command.consul.CreateConsulClusterCommand.COMMAND_NAME;
+import static com.nike.cerberus.ConfigConstants.SKIP_AMI_TAG_CHECK_ARG;
+import static com.nike.cerberus.ConfigConstants.SKIP_AMI_TAG_CHECK_DESCRIPTION;
 
 /**
  * Command to create the consul cluster.
@@ -33,8 +35,6 @@ import static com.nike.cerberus.command.consul.CreateConsulClusterCommand.COMMAN
 public class CreateConsulClusterCommand implements Command {
 
     public static final String COMMAND_NAME = "create-consul-cluster";
-
-    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
 
     @ParametersDelegate
     private StackDelegate stackDelegate = new StackDelegate();
@@ -49,7 +49,7 @@ public class CreateConsulClusterCommand implements Command {
     }
 
     @Parameter(names = SKIP_AMI_TAG_CHECK_ARG,
-            description = "Flag for skipping validation of AMI with matching stackname tags")
+            description = SKIP_AMI_TAG_CHECK_DESCRIPTION)
     private boolean skipAmiTagCheck;
 
     public boolean isSkipAmiTagCheck() {

--- a/src/main/java/com/nike/cerberus/command/core/UpdateStackCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/UpdateStackCommand.java
@@ -39,6 +39,7 @@ public class UpdateStackCommand implements Command {
     public static final String COMMAND_NAME = "update-stack";
     public static final String OVERWRITE_TEMPLATE_LONG_ARG = "--overwrite-template";
     public static final String PARAMETER_SHORT_ARG = "-P";
+    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
 
     @Parameter(names = {"--stack-name"}, required = true, description = "The stack name to update.")
     private StackName stackName;
@@ -77,6 +78,10 @@ public class UpdateStackCommand implements Command {
 
     @Parameter(names = StackDelegate.MIN_INSTANCES_LONG_ARG, description = "Minimum number of autos scaling instances")
     private Integer minimumInstances;
+
+    @Parameter(names = SKIP_AMI_TAG_CHECK_ARG,
+            description = "Flag for skipping validation of AMI with matching stackname tags")
+    private boolean skipAmiTagCheck;
 
     @DynamicParameter(names = PARAMETER_SHORT_ARG, description = "Dynamic parameters for overriding the values for specific parameters in the CloudFormation.")
     private Map<String, String> dynamicParameters = new HashMap<>();
@@ -127,6 +132,10 @@ public class UpdateStackCommand implements Command {
 
     public Integer getMinimumInstances() {
         return minimumInstances;
+    }
+
+    public boolean isSkipAmiTagCheck() {
+        return skipAmiTagCheck;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/command/core/UpdateStackCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/UpdateStackCommand.java
@@ -29,6 +29,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.nike.cerberus.command.core.UpdateStackCommand.COMMAND_NAME;
+import static com.nike.cerberus.ConfigConstants.SKIP_AMI_TAG_CHECK_ARG;
+import static com.nike.cerberus.ConfigConstants.SKIP_AMI_TAG_CHECK_DESCRIPTION;
+
 
 /**
  * Command for updating the specified CloudFormation stack with the new parameters.
@@ -39,7 +42,6 @@ public class UpdateStackCommand implements Command {
     public static final String COMMAND_NAME = "update-stack";
     public static final String OVERWRITE_TEMPLATE_LONG_ARG = "--overwrite-template";
     public static final String PARAMETER_SHORT_ARG = "-P";
-    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
 
     @Parameter(names = {"--stack-name"}, required = true, description = "The stack name to update.")
     private StackName stackName;
@@ -80,7 +82,7 @@ public class UpdateStackCommand implements Command {
     private Integer minimumInstances;
 
     @Parameter(names = SKIP_AMI_TAG_CHECK_ARG,
-            description = "Flag for skipping validation of AMI with matching stackname tags")
+            description = SKIP_AMI_TAG_CHECK_DESCRIPTION)
     private boolean skipAmiTagCheck;
 
     @DynamicParameter(names = PARAMETER_SHORT_ARG, description = "Dynamic parameters for overriding the values for specific parameters in the CloudFormation.")

--- a/src/main/java/com/nike/cerberus/command/gateway/CreateGatewayClusterCommand.java
+++ b/src/main/java/com/nike/cerberus/command/gateway/CreateGatewayClusterCommand.java
@@ -35,6 +35,7 @@ public class CreateGatewayClusterCommand implements Command {
     public static final String COMMAND_NAME = "create-gateway-cluster";
     public static final String HOSTED_ZONE_ID_LONG_ARG = "--hosted-zone-id";
     public static final String HOSTNAME_LONG_ARG = "--hostname";
+    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
 
     @Parameter(names = HOSTED_ZONE_ID_LONG_ARG,
             description = "The Route 53 hosted zone ID that will be used to create the CNAME record for Cerberus.",
@@ -46,6 +47,10 @@ public class CreateGatewayClusterCommand implements Command {
             required = true)
     private String hostname;
 
+    @Parameter(names = SKIP_AMI_TAG_CHECK_ARG,
+            description = "Flag for skipping validation of AMI with matching stackname tags")
+    private boolean skipAmiTagCheck;
+
     @ParametersDelegate
     private StackDelegate stackDelegate = new StackDelegate();
 
@@ -55,6 +60,10 @@ public class CreateGatewayClusterCommand implements Command {
 
     public String getHostname() {
         return hostname;
+    }
+
+    public boolean isSkipAmiTagCheck() {
+        return skipAmiTagCheck;
     }
 
     public StackDelegate getStackDelegate() {

--- a/src/main/java/com/nike/cerberus/command/gateway/CreateGatewayClusterCommand.java
+++ b/src/main/java/com/nike/cerberus/command/gateway/CreateGatewayClusterCommand.java
@@ -25,6 +25,8 @@ import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.gateway.CreateGatewayClusterOperation;
 
 import static com.nike.cerberus.command.gateway.CreateGatewayClusterCommand.COMMAND_NAME;
+import static com.nike.cerberus.ConfigConstants.SKIP_AMI_TAG_CHECK_ARG;
+import static com.nike.cerberus.ConfigConstants.SKIP_AMI_TAG_CHECK_DESCRIPTION;
 
 /**
  * Command to create the Gateway cluster.
@@ -35,7 +37,6 @@ public class CreateGatewayClusterCommand implements Command {
     public static final String COMMAND_NAME = "create-gateway-cluster";
     public static final String HOSTED_ZONE_ID_LONG_ARG = "--hosted-zone-id";
     public static final String HOSTNAME_LONG_ARG = "--hostname";
-    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
 
     @Parameter(names = HOSTED_ZONE_ID_LONG_ARG,
             description = "The Route 53 hosted zone ID that will be used to create the CNAME record for Cerberus.",
@@ -48,7 +49,7 @@ public class CreateGatewayClusterCommand implements Command {
     private String hostname;
 
     @Parameter(names = SKIP_AMI_TAG_CHECK_ARG,
-            description = "Flag for skipping validation of AMI with matching stackname tags")
+            description = SKIP_AMI_TAG_CHECK_DESCRIPTION)
     private boolean skipAmiTagCheck;
 
     @ParametersDelegate

--- a/src/main/java/com/nike/cerberus/command/vault/CreateVaultClusterCommand.java
+++ b/src/main/java/com/nike/cerberus/command/vault/CreateVaultClusterCommand.java
@@ -25,6 +25,8 @@ import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.vault.CreateVaultClusterOperation;
 
 import static com.nike.cerberus.command.vault.CreateVaultClusterCommand.COMMAND_NAME;
+import static com.nike.cerberus.ConfigConstants.SKIP_AMI_TAG_CHECK_ARG;
+import static com.nike.cerberus.ConfigConstants.SKIP_AMI_TAG_CHECK_DESCRIPTION;
 
 /**
  * Command to create the Vault cluster.
@@ -33,8 +35,6 @@ import static com.nike.cerberus.command.vault.CreateVaultClusterCommand.COMMAND_
 public class CreateVaultClusterCommand implements Command {
 
     public static final String COMMAND_NAME = "create-vault-cluster";
-
-    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
 
     @ParametersDelegate
     private StackDelegate stackDelegate = new StackDelegate();
@@ -49,7 +49,7 @@ public class CreateVaultClusterCommand implements Command {
     }
 
     @Parameter(names = SKIP_AMI_TAG_CHECK_ARG,
-            description = "Flag for skipping validation of AMI with matching stackname tags")
+            description = SKIP_AMI_TAG_CHECK_DESCRIPTION)
     private boolean skipAmiTagCheck;
 
     public boolean isSkipAmiTagCheck() {

--- a/src/main/java/com/nike/cerberus/command/vault/CreateVaultClusterCommand.java
+++ b/src/main/java/com/nike/cerberus/command/vault/CreateVaultClusterCommand.java
@@ -16,6 +16,7 @@
 
 package com.nike.cerberus.command.vault;
 
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
@@ -33,6 +34,8 @@ public class CreateVaultClusterCommand implements Command {
 
     public static final String COMMAND_NAME = "create-vault-cluster";
 
+    public static final String SKIP_AMI_TAG_CHECK_ARG = "--skip-ami-tag-check";
+
     @ParametersDelegate
     private StackDelegate stackDelegate = new StackDelegate();
 
@@ -43,6 +46,14 @@ public class CreateVaultClusterCommand implements Command {
     @Override
     public String getCommandName() {
         return COMMAND_NAME;
+    }
+
+    @Parameter(names = SKIP_AMI_TAG_CHECK_ARG,
+            description = "Flag for skipping validation of AMI with matching stackname tags")
+    private boolean skipAmiTagCheck;
+
+    public boolean isSkipAmiTagCheck() {
+        return skipAmiTagCheck;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/operation/vault/CreateVaultClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/vault/CreateVaultClusterOperation.java
@@ -30,6 +30,7 @@ import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.UnexpectedCloudFormationStatusException;
 import com.nike.cerberus.service.CloudFormationService;
 import com.nike.cerberus.service.Ec2UserDataService;
+import com.nike.cerberus.service.AmiTagCheckService;
 import com.nike.cerberus.store.ConfigStore;
 import com.nike.cerberus.util.UuidSupplier;
 import org.apache.commons.lang3.StringUtils;
@@ -56,6 +57,8 @@ public class CreateVaultClusterOperation implements Operation<CreateVaultCluster
 
     private final Ec2UserDataService ec2UserDataService;
 
+    private final AmiTagCheckService amiTagCheckService;
+
     private final UuidSupplier uuidSupplier;
 
     private final ConfigStore configStore;
@@ -66,12 +69,14 @@ public class CreateVaultClusterOperation implements Operation<CreateVaultCluster
     public CreateVaultClusterOperation(final EnvironmentMetadata environmentMetadata,
                                        final CloudFormationService cloudFormationService,
                                        final Ec2UserDataService ec2UserDataService,
+                                       final AmiTagCheckService amiTagCheckService,
                                        final UuidSupplier uuidSupplier,
                                        final ConfigStore configStore,
                                        @Named(CF_OBJECT_MAPPER) final ObjectMapper cloudformationObjectMapper) {
         this.environmentMetadata = environmentMetadata;
         this.cloudFormationService = cloudFormationService;
         this.ec2UserDataService = ec2UserDataService;
+        this.amiTagCheckService = amiTagCheckService;
         this.uuidSupplier = uuidSupplier;
         this.configStore = configStore;
         this.cloudformationObjectMapper = cloudformationObjectMapper;
@@ -87,6 +92,11 @@ public class CreateVaultClusterOperation implements Operation<CreateVaultCluster
 
         if (!vaultServerCertificateArn.isPresent() || !pubKey.isPresent()) {
             throw new IllegalStateException("Vault server certificate has not been uploaded!");
+        }
+
+        // Make sure the given AmiId is for Vault component. Check if it contains required tag
+        if ( !command.isSkipAmiTagCheck() ) {
+            amiTagCheckService.validateAmiTagForStack(command.getStackDelegate().getAmiId(), StackName.VAULT);
         }
 
         final VaultParameters vaultParameters = new VaultParameters()

--- a/src/main/java/com/nike/cerberus/service/AmiTagCheckService.java
+++ b/src/main/java/com/nike/cerberus/service/AmiTagCheckService.java
@@ -82,7 +82,7 @@ public class AmiTagCheckService {
      */
     public void validateAmiTagForStack(final String amiId, final StackName stackName) {
         if (!isAmiWithTagExist(amiId, ConfigConstants.CERBERUS_AMI_TAG_NAME, stackAmiTagValueMap.get(stackName) )) {
-            throw new IllegalStateException("AMI tag check failed!. Given AMI ID does not contain cerberus tag 'cerberus_component' with stack name");
+            throw new IllegalStateException(ConfigConstants.AMI_TAG_CHECK_ERROR_MESSAGE);
         }
     }
 }

--- a/src/main/java/com/nike/cerberus/service/AmiTagCheckService.java
+++ b/src/main/java/com/nike/cerberus/service/AmiTagCheckService.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.service;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.Filter;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.nike.cerberus.domain.environment.StackName;
+import com.nike.cerberus.ConfigConstants;
+
+/**
+ * Service wrapper for AWS EC2.
+ */
+public class AmiTagCheckService {
+
+    private final AmazonEC2 ec2Client;
+
+    private final Map<StackName, String> stackAmiTagValueMap;
+
+    @Inject
+    public AmiTagCheckService(final AmazonEC2 ec2Client) {
+        this.ec2Client = ec2Client;
+
+        stackAmiTagValueMap = new HashMap<>();
+        stackAmiTagValueMap.put(StackName.CONSUL, ConfigConstants.CONSUL_AMI_TAG_VALUE);
+        stackAmiTagValueMap.put(StackName.VAULT, ConfigConstants.VAULT_AMI_TAG_VALUE);
+        stackAmiTagValueMap.put(StackName.CMS, ConfigConstants.CMS_AMI_TAG_VALUE);
+        stackAmiTagValueMap.put(StackName.GATEWAY, ConfigConstants.GATEWAY_AMI_TAG_VALUE);
+
+    }
+
+    /**
+     * Validates if the given AMI has given tag and value.
+     *
+     * @return true if matches otherwise false
+     */
+    public boolean isAmiWithTagExist(final String amiId, final String tagName, final String tagValue) {
+
+        final DescribeImagesRequest request = new DescribeImagesRequest()
+            .withFilters(new Filter().withName(tagName).withValues(tagValue))
+            .withFilters(new Filter().withName("image-id").withValues(amiId));
+
+        try {
+            final DescribeImagesResult result = ec2Client.describeImages(request);
+            return result.getImages().size() > 0;
+        } catch (final AmazonServiceException ase) {
+            if (ase.getErrorCode() == "InvalidAMIID.NotFound") {
+                return false;
+            }
+
+            throw ase;
+        }
+    }
+
+    /**
+     * Validates if the given AMI has given cerberus tag and value.
+     *
+     * @return void
+     */
+    public void validateAmiTagForStack(final String amiId, final StackName stackName) {
+        if (!isAmiWithTagExist(amiId, ConfigConstants.CERBERUS_AMI_TAG_NAME, stackAmiTagValueMap.get(stackName) )) {
+            throw new IllegalStateException("AMI tag check failed!. Given AMI ID does not contain cerberus tag 'cerberus_component' with stack name");
+        }
+    }
+}

--- a/src/test/java/com/nike/cerberus/service/AmiTagCheckServiceTest.java
+++ b/src/test/java/com/nike/cerberus/service/AmiTagCheckServiceTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2016 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.service;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.DescribeImagesRequest;
+import com.amazonaws.services.ec2.model.DescribeImagesResult;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.model.Image;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AmiTagCheckServiceTest {
+
+    @Test
+    public void isAmiWithTagExistTrue() {
+        AmazonEC2 ec2Client = mock(AmazonEC2.class);
+        AmiTagCheckService amiTagCheckService = new AmiTagCheckService(ec2Client);
+
+        String amiId = "ami-1234abcd";
+        String tagName = "sometag";
+        String tagValue = "someval";
+
+        when(ec2Client.describeImages(
+                new DescribeImagesRequest()
+                        .withFilters(new Filter().withName(tagName).withValues(tagValue))
+                        .withFilters(new Filter().withName("image-id").withValues(amiId))
+                )
+        ).thenReturn(
+                new DescribeImagesResult().withImages(new Image())
+                );
+
+        // invoke method under test
+        assertTrue(amiTagCheckService.isAmiWithTagExist(amiId, tagName, tagValue));
+    }
+
+    @Test
+    public void isAmiWithTagExistFalse() {
+        AmazonEC2 ec2Client = mock(AmazonEC2.class);
+        AmiTagCheckService amiTagCheckService = new AmiTagCheckService(ec2Client);
+
+        String amiId = "ami-1234abcd";
+        String tagName = "sometag";
+        String tagValue = "someval";
+
+        when(ec2Client.describeImages(
+                new DescribeImagesRequest()
+                        .withFilters(new Filter().withName(tagName).withValues(tagValue))
+                        .withFilters(new Filter().withName("image-id").withValues(amiId))
+                )
+        ).thenReturn(
+                new DescribeImagesResult()
+                );
+
+        // invoke method under test
+        assertFalse(amiTagCheckService.isAmiWithTagExist(amiId, tagName, tagValue));
+    }
+
+    @Test
+    public void isAmiWithTagExistNotFound() {
+        AmazonEC2 ec2Client = mock(AmazonEC2.class);
+        AmiTagCheckService amiTagCheckService = new AmiTagCheckService(ec2Client);
+
+        String amiId = "ami-1234abcd";
+        String tagName = "sometag";
+        String tagValue = "someval";
+
+        AmazonServiceException ex = new AmazonServiceException("fake-exception");
+        ex.setErrorCode("InvalidAMIID.NotFound");
+
+        when(ec2Client.describeImages(
+                new DescribeImagesRequest()
+                        .withFilters(new Filter().withName(tagName).withValues(tagValue))
+                        .withFilters(new Filter().withName("image-id").withValues(amiId))
+                )
+        ).thenThrow(ex);
+
+        // invoke method under test
+        assertFalse(amiTagCheckService.isAmiWithTagExist(amiId, tagName, tagValue));
+    }
+
+    @Test
+    public void isAmiWithTagExistThrowException() {
+        AmazonEC2 ec2Client = mock(AmazonEC2.class);
+        AmiTagCheckService amiTagCheckService = new AmiTagCheckService(ec2Client);
+
+        String amiId = "ami-1234abcd";
+        String tagName = "sometag";
+        String tagValue = "someval";
+        String unknownAwsExMessage = "Unknown AWS exception message";
+
+        when(ec2Client.describeImages(
+                new DescribeImagesRequest()
+                        .withFilters(new Filter().withName(tagName).withValues(tagValue))
+                        .withFilters(new Filter().withName("image-id").withValues(amiId))
+                )
+        ).thenThrow(new AmazonServiceException(unknownAwsExMessage));
+
+        try {
+            // invoke method under test
+            amiTagCheckService.isAmiWithTagExist(amiId, tagName, tagValue);
+            fail("Expected exception message '" + unknownAwsExMessage + "'not received");
+        } catch (AmazonServiceException ex) {
+            // pass
+            assertEquals(unknownAwsExMessage, ex.getErrorMessage());
+        }
+    }
+}


### PR DESCRIPTION
**Feature: Validate AMI tag before creating or deploying any component**

When creating a new environment or deploying a new component, validate if the given AMI ID has 'cerberus_component' tag and it matches the component name. Fail the deployment when it fails to match this requirement.

By default this check is enforced. Use command option `--skip-ami-tag-check` to skip this check.