### PR TITLE
Increase the grace period for CMS to start up

### DIFF
--- a/smaas-cf/smaas/cms-cluster.py
+++ b/smaas-cf/smaas/cms-cluster.py
@@ -243,7 +243,7 @@ launch_config = template.add_resource(LaunchConfiguration(
 autoscaling_group = template.add_resource(AutoScalingGroup(
         "CmsAutoScalingGroup",
         DesiredCapacity=Ref(desired_instances_param),
-        HealthCheckGracePeriod=360,
+        HealthCheckGracePeriod=900,
         HealthCheckType="ELB",
         LaunchConfigurationName=Ref(launch_config),
         LoadBalancerNames=[


### PR DESCRIPTION
Increase the grace period to 15 mins to match the CloudFormation signal timeout.