### PR TITLE
Misc usability improvements

### DIFF
--- a/src/main/java/com/nike/cerberus/command/cms/UpdateCmsConfigCommand.java
+++ b/src/main/java/com/nike/cerberus/command/cms/UpdateCmsConfigCommand.java
@@ -40,7 +40,7 @@ public class UpdateCmsConfigCommand implements Command {
     @Parameter(names = CreateCmsConfigCommand.ADMIN_GROUP_LONG_ARG, description = "Group that has admin privileges in CMS.")
     private String adminGroup;
 
-    @Parameter(names = OVERWRITE_LONG_ARG, description = "Overwrite -P parameters completely.")
+    @Parameter(names = OVERWRITE_LONG_ARG, description = "Overwrite option deletes any existing -P parameters that were not resupplied (this option is not usually needed).")
     private boolean overwrite;
 
     @DynamicParameter(names = CreateCmsConfigCommand.PROPERTY_SHORT_ARG, description = "Dynamic parameters for setting additional properties in the CMS environment configuration.")

--- a/src/main/java/com/nike/cerberus/operation/vault/InitVaultClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/vault/InitVaultClusterOperation.java
@@ -51,6 +51,8 @@ public class InitVaultClusterOperation implements Operation<InitVaultClusterComm
 
     @Override
     public void run(final InitVaultClusterCommand command) {
+        logger.info("If you just created the Vault cluster, this command will fail until the Vault cluster has a chance to initialize.  If that happens, just try again in a few minutes.");
+
         logger.info("Getting clients for Vault instances.");
         final List<VaultAdminClient> clients = vaultAdminClientFactory.getClientsForCluster();
 


### PR DESCRIPTION
Minor improvements to existing commands:
- `init-vault-cluster` adding helpful log message
- `update-cms-config` clarifying usage of -P parameter

