### PR TITLE
Changing back TLS policy for CloudFront

### DIFF
--- a/smaas-cf/smaas/gateway-cluster.py
+++ b/smaas-cf/smaas/gateway-cluster.py
@@ -707,7 +707,7 @@ gateway_distribution = template.add_resource(Distribution(
         PriceClass="PriceClass_100",
         ViewerCertificate=ViewerCertificate(
             IamCertificateId=Ref(ssl_certificate_id_param),
-            MinimumProtocolVersion="TLSv1.1_2016",
+            MinimumProtocolVersion="TLSv1",
             SslSupportMethod="sni-only"
         ),
         WebACLId=Ref(web_acl),


### PR DESCRIPTION
- Changing it back because there are possibly some older clients not ready for the new policy.  Will make necessary changes in clients before upgrading to TLSv.1.2