### PR TITLE
Add Generate Cert Command/Operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,9 @@ gradle-app.setting
 
 # Python cache
 **/__pycache__/
+/certs/
+build/certs/
+*.pem
+*.key
+*.crt
+*.csr

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ allprojects {
         jcenter()
     }
 
-    def awsSDKVersion = '1.11.155'
+    def awsSDKVersion = '1.11.220'
 
     //noinspection GroovyAssignabilityCheck
     dependencies {
@@ -33,6 +33,8 @@ allprojects {
         compile group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: awsSDKVersion
         compile group: 'com.amazonaws', name: 'aws-java-sdk-sns', version: awsSDKVersion
         compile group: 'com.amazonaws', name: 'aws-java-sdk-lambda', version: awsSDKVersion
+        compile group: 'com.amazonaws', name: 'aws-java-sdk-route53', version: awsSDKVersion
+
 
         compile 'com.nike:vault-client:1.4.1'
         compile 'com.squareup.okhttp3:okhttp:3.3.1'
@@ -57,9 +59,23 @@ allprojects {
         compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
         compile group: 'com.google.code.findbugs', name: 'annotations', version: '3.0.0'
 
+        // Cert Generation
+        compile group: 'dnsjava', name: 'dnsjava', version: '2.1.8'
+        compile group: 'org.shredzone.acme4j', name: 'acme4j-client', version: '0.13'
+        compile group: 'org.shredzone.acme4j', name: 'acme4j-utils', version: '0.13'
+
         testCompile "junit:junit:4.12"
         testCompile ("org.mockito:mockito-core:1.10.19") {
             exclude group: 'org.hamcrest'
         }
+        testCompile 'com.fieldju:commons:1.2.0'
+        testCompile group: 'io.netty', name: 'netty-handler', version: '4.1.16.Final'
+
     }
+
+    configurations.all {
+        // check for updates every build
+        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
+
 }

--- a/gradle/integration.gradle
+++ b/gradle/integration.gradle
@@ -34,3 +34,9 @@ task integrationTest(type: Test) {
     testClassesDir = sourceSets.integrationTest.output.classesDir
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
+
+integrationTest {
+    testLogging {
+        showStandardStreams = true
+    }
+}

--- a/src/integration-test/java/com/nike/cerberus/operation/core/GenerateCertsOperationIntegrationTest.java
+++ b/src/integration-test/java/com/nike/cerberus/operation/core/GenerateCertsOperationIntegrationTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.operation.core;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient;
+import com.amazonaws.services.identitymanagement.model.DeleteServerCertificateRequest;
+import com.amazonaws.services.identitymanagement.model.UploadServerCertificateRequest;
+import com.amazonaws.services.identitymanagement.model.UploadServerCertificateResult;
+import com.amazonaws.services.route53.AmazonRoute53Client;
+import com.google.common.collect.ImmutableSet;
+import com.nike.cerberus.command.core.GenerateCertsCommand;
+import com.nike.cerberus.domain.EnvironmentMetadata;
+import com.nike.cerberus.service.CertificateService;
+import com.nike.cerberus.service.ConsoleService;
+import io.netty.handler.ssl.SslContextBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import static com.fieldju.commons.PropUtils.getPropWithDefaultValue;
+import static com.fieldju.commons.PropUtils.getRequiredProperty;
+import static com.nike.cerberus.service.CertificateService.CERT_CHAIN;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_CERT;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_CSR_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_FULL_CERT_WITH_CHAIN_CRT;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_PKCS1_KEY_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_PKCS8_KEY_FILE;
+import static com.nike.cerberus.service.CertificateService.USER_KEY_FILE;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.contains;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * This integration test will generate certs using an provided ACME api and test that the certs are usable my an AWS ALB and Netty's SSL Context Builder.
+ *
+ * Running this Integration Test will automatically accept the TOS of the ACME provider if present.
+ * By Running this test you are agreeing with the Terms of Service of the ACME Provider API you provide.
+ *
+ * Required Props (can be set via env or system props)
+ *
+ * CERT_GEN_TEST_DOMAIN: A domain that will be used as the common name for the generated certs,
+ *      you must also provide a hosted zone id that can create records for this domain.
+ *
+ * CERT_GEN_HOSTED_ZONE_ID: The hosted zone id that can create records for CERT_GEN_TEST_DOMAIN
+ *
+ * CERT_GEN_CONTACT_EMAIL: The email to use as the contact when generating the cert
+ *
+ * Optional Props
+ *
+ * CERT_GEN_ACME_API: the ACME api to test against, defaults to 'acme://letsencrypt.org/staging'
+ *
+ * EX: CERT_GEN_TEST_DOMAIN=cerberus-oss.io  CERT_GEN_HOSTED_ZONE_ID=123123 CERT_GEN_CONTACT_EMAIL=justin.field@nike.com ./gradlew clean integrationTest -DintegrationTest.debug -DintegrationTest.single=GenerateCertsOperationIntegrationTest
+ *
+ */
+public class GenerateCertsOperationIntegrationTest {
+
+    public static String CERT_DIR = "build/certs/";
+
+    @Mock
+    private GenerateCertsCommand command;
+
+    @Mock
+    private ConsoleService consoleService;
+
+    @Mock
+    private EnvironmentMetadata environmentMetadata;
+
+    private GenerateCertsOperation operation;
+
+    private File certDir;
+
+    @Before
+    public void before() {
+        initMocks(this);
+
+        CertificateService certificateService = new CertificateService(consoleService,
+                AmazonRoute53Client.builder().withRegion("us-west-2").build());
+
+        operation = new GenerateCertsOperation(certificateService, environmentMetadata, consoleService);
+
+        certDir = new File(CERT_DIR);
+    }
+
+    @Test
+    public void test_that_command_generates_valid_certs() throws IOException {
+        when(environmentMetadata.getName()).thenReturn("integration-test");
+        when(environmentMetadata.getRegionName()).thenReturn("us-west-2");
+        when(command.getBaseDomainName()).thenReturn(getRequiredProperty("CERT_GEN_TEST_DOMAIN",
+                "CERT_GEN_TEST_DOMAIN is a required env or system prop and must be a domain that you have a" +
+                        " hosted zone for that can create records"));
+        when(command.getHostedZoneId()).thenReturn(getRequiredProperty("CERT_GEN_HOSTED_ZONE_ID",
+                "The hosted zone id that can create records for CERT_GEN_TEST_DOMAIN"));
+        when(consoleService.readLine(contains("Would you like to proceed?"))).thenReturn("y");
+        when(command.enableLetsEncryptCertfix()).thenReturn(true);
+        when(command.getCertDir()).thenReturn(certDir.getAbsolutePath());
+        when(consoleService.readLine(contains("accept")))
+                .thenReturn("i accept");
+        when(command.getAcmeApiUrl()).thenReturn(getPropWithDefaultValue("CERT_GEN_ACME_API",
+                "acme://letsencrypt.org/staging"));
+        when(command.getContactEmail()).thenReturn(getRequiredProperty("CERT_GEN_CONTACT_EMAIL",
+                "The email contact to use when generating the cert"));
+
+        operation.run(command);
+
+        ImmutableSet.of(
+                USER_KEY_FILE,
+                DOMAIN_PKCS1_KEY_FILE,
+                DOMAIN_PKCS8_KEY_FILE,
+                DOMAIN_CSR_FILE,
+                DOMAIN_FULL_CERT_WITH_CHAIN_CRT,
+                DOMAIN_CERT,
+                CERT_CHAIN
+        ).forEach(expectedFileName -> {
+            File expectedFile = new File(certDir.getAbsolutePath() + File.separator + expectedFileName);
+            assertTrue("The expected file should exist after running the generate certs command", expectedFile.exists());
+        });
+
+        // test that the certs are usable by and ALB
+        assertThatCertsAreUsableByAws();
+
+        // test that the PKCS8 Private key and ACME generated cert are loadable by CMS
+        assertThatCertsAreUsableByCms();
+
+        System.out.println("The Keys and Certificates where properly generated and passed validation");
+    }
+
+    private void assertThatCertsAreUsableByAws() throws IOException {
+        String uuid = UUID.randomUUID().toString();
+        AmazonIdentityManagement amazonIdentityManagement = AmazonIdentityManagementClient.builder().withRegion(Regions.DEFAULT_REGION).build();
+        final UploadServerCertificateRequest request = new UploadServerCertificateRequest()
+                .withServerCertificateName("cert-gen-integration-test-" + uuid)
+                .withPath("/cert-gen-integration-test/" + uuid + "/")
+                .withCertificateBody(new String(Files.readAllBytes((new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CERT).toPath()))))
+                .withCertificateChain(new String(Files.readAllBytes((new File(certDir.getAbsolutePath() + File.separator + CERT_CHAIN).toPath()))))
+                .withPrivateKey(new String(Files.readAllBytes(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_PKCS1_KEY_FILE).toPath())));
+
+        final UploadServerCertificateResult result = amazonIdentityManagement.uploadServerCertificate(request);
+
+        assertTrue(StringUtils.isNotBlank(result.getServerCertificateMetadata().getArn()));
+
+        amazonIdentityManagement.deleteServerCertificate(
+                new DeleteServerCertificateRequest()
+                        .withServerCertificateName(result.getServerCertificateMetadata().getServerCertificateName())
+        );
+    }
+
+    private void assertThatCertsAreUsableByCms() {
+        String[] cmsSupportedProtocols = new String[] {
+                "TLSv1.2"
+        };
+
+        try {
+            SslContextBuilder.forServer(
+                    new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CERT),
+                    new File(certDir.getAbsolutePath() + File.separator + DOMAIN_PKCS8_KEY_FILE)
+            ).protocols(cmsSupportedProtocols).build();
+        } catch (Exception e) {
+            fail("Failed to generate the SSL Context that CMS uses to validate Cert and PKCS8 private key. Reason: " + e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/nike/cerberus/ConfigConstants.java
+++ b/src/main/java/com/nike/cerberus/ConfigConstants.java
@@ -42,8 +42,6 @@ public class ConfigConstants {
 
     public static final String CERT_PART_KEY = "key.pem";
 
-    public static final String CERT_PART_PUBKEY = "pubkey.pem";
-
     public static final String BASE_STACK_NAME = "base";
 
     public static final String BASE_STACK_TEMPLATE_PATH = "/cloudformation/vpc-and-base.json";

--- a/src/main/java/com/nike/cerberus/cli/CerberusRunner.java
+++ b/src/main/java/com/nike/cerberus/cli/CerberusRunner.java
@@ -32,6 +32,7 @@ import com.nike.cerberus.command.cms.CreateCmsCmkCommand;
 import com.nike.cerberus.command.cms.CreateCmsConfigCommand;
 import com.nike.cerberus.command.cms.UpdateCmsConfigCommand;
 import com.nike.cerberus.command.core.CreateCerberusBackupCommand;
+import com.nike.cerberus.command.core.GenerateCertsCommand;
 import com.nike.cerberus.command.core.RollingRebootWithHealthCheckCommand;
 import com.nike.cerberus.command.core.ViewConfigCommand;
 import com.nike.cerberus.command.core.CreateBaseCommand;
@@ -170,6 +171,7 @@ public class CerberusRunner {
         registerCommand(new RollingRebootWithHealthCheckCommand());
         registerCommand(new CreateCerberusBackupCommand());
         registerCommand(new SetBackupAdminPrincipalsCommand());
+        registerCommand(new GenerateCertsCommand());
     }
 
     /**

--- a/src/main/java/com/nike/cerberus/command/core/GenerateCertsCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/GenerateCertsCommand.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.command.core;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.nike.cerberus.command.Command;
+import com.nike.cerberus.operation.Operation;
+import com.nike.cerberus.operation.core.GenerateCertsOperation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.nike.cerberus.command.core.GenerateCertsCommand.COMMAND_DESCRIPTION;
+import static com.nike.cerberus.command.core.GenerateCertsCommand.COMMAND_NAME;
+
+@Parameters(
+        commandNames = COMMAND_NAME,
+        commandDescription = COMMAND_DESCRIPTION
+)
+public class GenerateCertsCommand implements Command {
+
+    public static final String COMMAND_NAME = "generate-certs";
+    public static final String COMMAND_DESCRIPTION = "Generates the TLS certificates needed to enable https " +
+            "through out the system, using an ACME provider such as LetsEncrypt";
+
+    public static final String BASE_DOMAIN_LONG_ARG = "--base-domain";
+    public static final String BASE_DOMAIN_SHORT_ARG = "-d";
+
+    public static final String HOSTED_ZONE_ID_LONG_ARG = "--hosted-zone-id";
+    public static final String HOSTED_ZONE_ID_SHORT_ARG = "-h";
+
+    public static final String ADDITIONAL_SUBJECT_ALT_NAME_LONG_ARG = "--additional-subject-alternative-name";
+    public static final String ADDITIONAL_SUBJECT_ALT_NAME_SHORT_ARG = "-a";
+
+    public static final String ENABLE_LE_CERTFIX_LONG_ARG = "--enable-letsecrypt-certfix";
+    public static final String ENABLE_LE_CERTFIX_SHORT_ARG = "-elec";
+
+    public static final String CERT_FOLDER_LONG_ARG = "--cert-dir";
+    public static final String CERT_FOLDER_SHORT_ARG = "-c";
+
+    public static final String ACME_API_LONG_ARG = "--acme-api-url";
+    public static final String ACME_API_SHORT_ARG = "-u";
+
+    public static final String LETS_ENCRYPT_ACME_API_URI = "acme://letsencrypt.org";
+
+    public static final String CONTACT_EMAIL_LONG_ARG = "--contact-email";
+    public static final String CONTACT_EMAIL_SHORT_ARG = "-c";
+
+    @Parameter(
+            names = {
+                    BASE_DOMAIN_LONG_ARG,
+                    BASE_DOMAIN_SHORT_ARG
+            },
+            description = "The base domain for the environment that this command will use to generate the following " +
+                    "subject name {env}.{base-domain} and with the following subject alternative name {env}.{region}.{base-domain}\n" +
+                    "ex: cerberus -e demo -r us-west-2 generate-certs -d cerberus-oss.io would make a cert for demo.cerberus-oss.io " +
+                    "with a sans of demo.us-west-2.cerberus-oss.io so that we can create a CNAME record for " +
+                    "demo.cerberus-oss.io that will point to an ALB in us-west-2 with a CNAME record of " +
+                    "demo.us-west-2.cerberus-oss.io and the cert will be valid for both",
+            required = true
+    )
+    private String baseDomainName;
+
+    public String getBaseDomainName() {
+        return baseDomainName;
+    }
+
+    @Parameter(
+            names = {
+                    HOSTED_ZONE_ID_LONG_ARG,
+                    HOSTED_ZONE_ID_SHORT_ARG
+            },
+            description = "The AWS Route 53 hosted zone id that is configured to create records for the base domain",
+            required = true
+    )
+    private String hostedZoneId;
+
+    public String getHostedZoneId() {
+        return hostedZoneId;
+    }
+
+    @Parameter(
+            names = {
+                    ADDITIONAL_SUBJECT_ALT_NAME_LONG_ARG,
+                    ADDITIONAL_SUBJECT_ALT_NAME_SHORT_ARG
+            },
+            description = "Alternative subject names, this should be any additional cnames that need to be secured. such as "
+    )
+    private List<String> subjectAlternativeNames = new ArrayList<>();
+
+    public List<String> getSubjectAlternativeNames() {
+        return subjectAlternativeNames;
+    }
+
+    @Parameter(
+            names = {
+                    ENABLE_LE_CERTFIX_LONG_ARG,
+                    ENABLE_LE_CERTFIX_SHORT_ARG
+            },
+            description = "This command uses the acme4j client to communicate with the ACME server, " +
+                    "it supports uses a hardcoded letsencrypt cert to get around ssl errors, you can use this " +
+                    "flag if your truststore is not configured to trust LE Certs, which can be found " +
+                    " here: https://letsencrypt.org/certificates/"
+    )
+    private boolean EnableLetsEncryptCertfix = false;
+
+    public boolean enableLetsEncryptCertfix() {
+        return EnableLetsEncryptCertfix;
+    }
+
+    @Parameter(
+            names = {
+                    CERT_FOLDER_LONG_ARG,
+                    CERT_FOLDER_SHORT_ARG
+            },
+            description = "The cert folder to store the generated files",
+            required = true
+    )
+    private String certDir;
+
+    public String getCertDir() {
+        return certDir;
+    }
+
+    @Parameter(
+            names = {
+                    ACME_API_LONG_ARG,
+                    ACME_API_SHORT_ARG
+            },
+            description = "The ACME API Url to use, This can be any ACME provider like LetsEncrypt: "  + LETS_ENCRYPT_ACME_API_URI,
+            required = true
+    )
+    private String acmeApiUrl;
+
+    public String getAcmeApiUrl() {
+        return acmeApiUrl;
+    }
+
+    @Parameter(
+            names = {
+                    CONTACT_EMAIL_LONG_ARG,
+                    CONTACT_EMAIL_SHORT_ARG
+            },
+            description = "The email contact to use when creating the certs",
+            required = true
+    )
+    private String contactEmail;
+
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    @Override
+    public String getCommandName() {
+        return COMMAND_NAME;
+    }
+
+    @Override
+    public Class<? extends Operation<?>> getOperationClass() {
+        return GenerateCertsOperation.class;
+    }
+}

--- a/src/main/java/com/nike/cerberus/operation/core/GenerateCertsOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/GenerateCertsOperation.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.operation.core;
+
+import com.nike.cerberus.command.core.GenerateCertsCommand;
+import com.nike.cerberus.domain.EnvironmentMetadata;
+import com.nike.cerberus.operation.Operation;
+import com.nike.cerberus.service.CertificateService;
+import com.nike.cerberus.service.ConsoleService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.nike.cerberus.service.ConsoleService.DefaultAction.NO;
+
+/**
+ * Operation that uses the cert service to generate the certificates needed to enable https in a Cerberus Env.
+ */
+public class GenerateCertsOperation implements Operation<GenerateCertsCommand> {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final CertificateService certService;
+    private final EnvironmentMetadata environmentMetadata;
+    private final ConsoleService consoleService;
+
+    @Inject
+    public GenerateCertsOperation(CertificateService certService,
+                                  EnvironmentMetadata environmentMetadata,
+                                  ConsoleService consoleService) {
+
+        this.certService = certService;
+        this.environmentMetadata = environmentMetadata;
+        this.consoleService = consoleService;
+    }
+
+    @SuppressFBWarnings(
+            value = "REC_CATCH_EXCEPTION",
+            justification = "I do not want to catch 1000 individual exceptions"
+    )
+    @Override
+    public void run(GenerateCertsCommand command) {
+        // The common name ex: demo.cerberus.io
+        String commonName = String.format("%s.%s", environmentMetadata.getName(), command.getBaseDomainName());
+        // The region specific subject alternate name. EX demo.us-west-2.ceberus.io
+        String regionSpecificSAN = String.format("%s.%s.%s",
+                environmentMetadata.getName(), environmentMetadata.getRegionName(), command.getBaseDomainName());
+
+        Set<String> subjectAlternativeNames = new HashSet<>();
+        subjectAlternativeNames.addAll(command.getSubjectAlternativeNames()); // add any additional SANs to the SAN set
+        subjectAlternativeNames.add(regionSpecificSAN); // add the default region specific san
+
+        // confirm with user
+        consoleService.askUserToProceed(String.format("Preparing to generate certs with Common Name: %s and Subject Alternative Names: %s",
+                        commonName, String.join(", ", subjectAlternativeNames)), NO);
+
+        // Enable the use of the hard coded lets encrypt cert if enabled
+        if (command.enableLetsEncryptCertfix()) {
+            log.warn("Setting acme4j.le.certfix system property to 'true', this only works if you use the special acme:// lets encrypt addr. See: https://shredzone.org/maven/acme4j/usage/session.html and https://shredzone.org/maven/acme4j/provider.html");
+            System.setProperty("acme4j.le.certfix", "true");
+        }
+
+        try {
+            // Use a temp dir or local dir if provided
+            File certDir = new File(command.getCertDir());
+
+            // check that we can write to the provided dir
+            FileUtils.forceMkdir(certDir);
+            if (! certDir.isDirectory() || ! certDir.canWrite()) {
+                throw new RuntimeException("Cert dir file is not a directory or is not writable, path: " + certDir.getAbsolutePath());
+            }
+
+            // generate the certs
+            certService.generateCerts(
+                    certDir,
+                    command.getAcmeApiUrl(),
+                    commonName,
+                    subjectAlternativeNames,
+                    command.getHostedZoneId(),
+                    command.getContactEmail()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate certs", e);
+        }
+    }
+
+    @Override
+    public boolean isRunnable(GenerateCertsCommand command) {
+        return true;
+    }
+}

--- a/src/main/java/com/nike/cerberus/service/CertificateService.java
+++ b/src/main/java/com/nike/cerberus/service/CertificateService.java
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.service;
+
+import com.amazonaws.services.route53.AmazonRoute53;
+import com.amazonaws.services.route53.model.Change;
+import com.amazonaws.services.route53.model.ChangeAction;
+import com.amazonaws.services.route53.model.ChangeBatch;
+import com.amazonaws.services.route53.model.ChangeResourceRecordSetsRequest;
+import com.amazonaws.services.route53.model.RRType;
+import com.amazonaws.services.route53.model.ResourceRecord;
+import com.amazonaws.services.route53.model.ResourceRecordSet;
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.shredzone.acme4j.Authorization;
+import org.shredzone.acme4j.Certificate;
+import org.shredzone.acme4j.Registration;
+import org.shredzone.acme4j.RegistrationBuilder;
+import org.shredzone.acme4j.Session;
+import org.shredzone.acme4j.Status;
+import org.shredzone.acme4j.challenge.Challenge;
+import org.shredzone.acme4j.challenge.Dns01Challenge;
+import org.shredzone.acme4j.exception.AcmeConflictException;
+import org.shredzone.acme4j.exception.AcmeException;
+import org.shredzone.acme4j.util.CSRBuilder;
+import org.shredzone.acme4j.util.CertificateUtils;
+import org.shredzone.acme4j.util.KeyPairUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.SimpleResolver;
+import org.xbill.DNS.Type;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Service for managing Cerificates and calls to the ACME cert provider
+ *
+ * TODO: Update TOS
+ * TODO: Rotate ACME user private key
+ * TODO: Support Venafi ACME Impl
+ */
+@SuppressFBWarnings(value = {
+        "DM_DEFAULT_ENCODING",
+        "REC_CATCH_EXCEPTION"
+})
+public class CertificateService {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    // File name of the PKCS #1 private key pem for the ACME registration, this represents a "User"
+    public static final String USER_KEY_FILE = "acme-user-private-key-pkcs1.pem";
+
+    // File name of the PKCS #1 private key pem for the Cerberus domain
+    public static final String DOMAIN_PKCS1_KEY_FILE = "domain-private-key-pkcs1.pem";
+
+    // File name of the PKCS #8 private key pem for the Cerberus domain
+    public static final String DOMAIN_PKCS8_KEY_FILE = "domain-private-key-pkcs8.pem";
+
+    // File name of the CSR
+    public static final String DOMAIN_CSR_FILE = "domain.csr";
+
+    // File name of the signed certificate
+    public static final String DOMAIN_FULL_CERT_WITH_CHAIN_CRT = "domain-full-cert-with-chain.crt";
+
+    // File name of the signed certificate
+    public static final String DOMAIN_CERT = "domain-cert.crt";
+
+    // File name of the ca chain
+    public static final String CERT_CHAIN = "chain.crt";
+
+    // RSA key size of generated key pairs
+    private static final int KEY_SIZE = 2048;
+
+    protected static final String CHALLENGE_ENTRY_TEMPLATE = "_acme-challenge.%s";
+
+    private final ConsoleService console;
+    private final AmazonRoute53 route53;
+
+    @Inject
+    public CertificateService(ConsoleService console,
+                              AmazonRoute53 route53) {
+
+        this.console = console;
+        this.route53 = route53;
+    }
+
+    /**
+     * Finds your {@link Registration} at the ACME server. It will be found by your user's
+     * public key. If your key is not known to the server yet, a new registration will be
+     * created.
+     * <p>
+     * This is a simple way of finding your {@link Registration}. A better way is to get
+     * the URI of your new registration with {@link Registration#getLocation()} and store
+     * it somewhere. If you need to get access to your account later, reconnect to it via
+     * {@link Registration#bind(Session, URI)} by using the stored location.
+     *
+     * @param session
+     *            {@link Session} to bind with
+     * @return {@link Registration} connected to your account
+     */
+    protected Registration findOrRegisterAccount(Session session, String contactEmail) throws AcmeException, IOException {
+        Registration reg;
+        try {
+            // Try to create a new Registration.
+            reg = new RegistrationBuilder().addContact("mailto:" + contactEmail).create(session);
+            log.info("Registered a new user, URI: " + reg.getLocation());
+
+            // This is a new account. Let the user accept the Terms of Service.
+            // We won't be able to authorize domains until the ToS is accepted.
+            URI agreement = reg.getAgreement();
+
+            if (! (agreement == null)) {
+                acceptAgreement(reg, agreement);
+            }
+        } catch (AcmeConflictException ex) {
+            // The Key Pair is already registered. getLocation() contains the
+            // URL of the existing registration's location. Bind it to the session.
+            reg = Registration.bind(session, ex.getLocation());
+            log.info("Account already exist, URI: {}, no need to create new account", reg.getLocation());
+        }
+        return reg;
+    }
+
+    /**
+     * Prompts a user to read and accept or deny a ACME providers TOS
+     *
+     * @param reg The registration object
+     * @param agreement The link to the TOS
+     */
+    protected void acceptAgreement(Registration reg, URI agreement) {
+        try {
+            log.info("Please download and review the Terms of Service: " + agreement);
+            String userResponse = console.readLine("Type \"I Accept\" to accept the Terms of Service, anything else will exit: ");
+            if (! StringUtils.equalsIgnoreCase("I Accept", userResponse)) {
+                throw new RuntimeException("User did not accept the Terms of Service");
+            }
+            reg.modify().setAgreement(agreement).commit();
+            log.info("Updated user's ToS");
+        } catch (AcmeException | IOException e) {
+            throw new RuntimeException("Failed to accept ACME TOS", e);
+        }
+    }
+
+    /**
+     * Creates a Txt record in Route53
+     *
+     * @param name The record name
+     * @param digest The value for the txt record
+     * @param hostedZoneId The hosted zone id to create the record in
+     */
+    protected void generateChallengeTxtEntry(String name, String digest, String hostedZoneId) {
+        ResourceRecordSet recordSet = new ResourceRecordSet()
+                .withName(name)
+                .withType(RRType.TXT)
+                .withTTL(10L)
+                .withResourceRecords(
+                        new ResourceRecord(String.format("\"%s\"", digest))
+                );
+
+        createOrUpdateRecordSets(recordSet, hostedZoneId);
+    }
+
+    protected void createOrUpdateRecordSets(ResourceRecordSet recordSet, String hostedZoneId) {
+        ChangeBatch changeBatch = new ChangeBatch().withChanges(
+                new Change()
+                        .withAction(ChangeAction.UPSERT)
+                        .withResourceRecordSet(recordSet)
+        );
+
+        route53.changeResourceRecordSets(new ChangeResourceRecordSetsRequest()
+                .withChangeBatch(changeBatch)
+                .withHostedZoneId(hostedZoneId));
+    }
+
+    /**
+     * Uses DNS to get a txt record
+     *
+     * @param cname the txt record to loop up
+     * @return Value of record if present
+     */
+    protected Optional<String> getTxtRecordValue(String cname) {
+        try {
+            Lookup lookup = new Lookup(cname, Type.TXT);
+            lookup.setResolver(new SimpleResolver());
+            lookup.setCache(null);
+            Record[] records = lookup.run();
+            return Optional.of(records[0].rdataToString());
+        } catch (Exception e) {
+            log.error("Failed to look up txt record for {} reason: {}", cname, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Loads a key pair from specified file. If the file does not exist,
+     * a new key pair is generated and saved.
+     *
+     * @return {@link KeyPair}.
+     */
+    protected KeyPair loadOrCreateKeyPair(File file) throws IOException {
+        if (file.exists()) {
+            try (FileReader fr = new FileReader(file)) {
+                return KeyPairUtils.readKeyPair(fr);
+            }
+        } else {
+            KeyPair domainKeyPair = KeyPairUtils.createKeyPair(KEY_SIZE);
+            try (FileWriter fw = new FileWriter(file)) {
+                KeyPairUtils.writeKeyPair(domainKeyPair, fw);
+            }
+            return domainKeyPair;
+        }
+    }
+
+
+    /**
+     * Generates the certs needed for a Cerberus Environment
+     *
+     * @param certDir The folder to store the generated files
+     * @param commonName The primary CNAME for the cert
+     * @param subjectAlternativeNames Additional CNAMEs for the cert
+     * @param hostedZoneId The hosted zone id that can be used to create txt records for the ACME ownership challenges
+     */
+    public void generateCerts(File certDir,
+                              String acmeServerUrl,
+                              String commonName,
+                              Set<String> subjectAlternativeNames,
+                              String hostedZoneId,
+                              String contactEmail) {
+
+        try {
+            List<String> names = new LinkedList<>();
+            names.add(commonName); // the first entry counts as the common name
+            names.addAll(subjectAlternativeNames);
+
+            KeyPair userKeyPair = loadOrCreateKeyPair(new File(certDir.getAbsolutePath() + File.separator + USER_KEY_FILE));
+
+            Session session = new Session(acmeServerUrl, userKeyPair);
+            Registration registration = findOrRegisterAccount(session, contactEmail);
+
+            for (String name : names) {
+                Authorization authorization = registration.authorizeDomain(name);
+                getChallenges(authorization).forEach(challenge -> doChallenge(challenge, name, hostedZoneId));
+            }
+
+            KeyPair domainKeyPair = loadOrCreateKeyPair(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_PKCS1_KEY_FILE));
+            createPKCS8PrivateKeyPemFileFromKeyPair(domainKeyPair, certDir);
+            CSRBuilder csrb = new CSRBuilder();
+            csrb.addDomains(names);
+            csrb.sign(domainKeyPair);
+
+            try (Writer csrWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CSR_FILE))) {
+                csrb.write(csrWriter);
+            }
+
+            // Now request a signed certificate.
+            Certificate certificate = registration.requestCertificate(csrb.getEncoded());
+
+            log.info("Success! The certificate has been generated!");
+            log.info("Certificate URI: " + certificate.getLocation());
+
+            // Download the leaf certificate and certificate chain.
+            X509Certificate cert = certificate.download();
+            X509Certificate[] chain = certificate.downloadChain();
+
+            // Write a combined file containing the certificate and chain.
+            try (FileWriter fullCertWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_FULL_CERT_WITH_CHAIN_CRT))) {
+                CertificateUtils.writeX509CertificateChain(fullCertWriter, cert, chain);
+            }
+            // write just the cert
+            try (FileWriter certWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CERT))) {
+                CertificateUtils.writeX509Certificate(cert, certWriter);
+            }
+            // write just the chain
+            try (FileWriter chainWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + CERT_CHAIN))) {
+                CertificateUtils.writeX509CertificateChain(chainWriter, null, chain);
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate certs", e);
+        }
+    }
+
+    /**
+     * Takes a challenge and performs it
+     *
+     * @param challenge The challenge
+     * @param domainName The domain that is being verified
+     * @param hostedZone The hosted zone id if applicable
+     */
+    protected void doChallenge(Challenge challenge, String domainName, String hostedZone) {
+        switch (challenge.getType()) {
+            case Dns01Challenge.TYPE:
+                doDns01Challenge((Dns01Challenge) challenge, domainName, hostedZone);
+                break;
+            default:
+                throw new RuntimeException("Unsupported challenge type: " + challenge.getType());
+        }
+    }
+
+    /**
+     * Attempts to get an acceptable challenge from the ACME provider.
+     *
+     * This CLI currently only supports DNS-01 Challenges
+     *
+     * @param authorization The authorization object from the ACME provider
+     * @return a Collection of challenges to complete.
+     */
+    protected Collection<Challenge> getChallenges(Authorization authorization) {
+        List<String[]> desiredChallengeCombos = ImmutableList.of(
+                new String[]{Dns01Challenge.TYPE}
+        );
+
+        for (String[] desiredChallengeCombo : desiredChallengeCombos) {
+            Collection<Challenge> challenges = authorization.findCombination(desiredChallengeCombo);
+            if (! challenges.isEmpty()) {
+                return challenges;
+            }
+        }
+
+        String apiSupportedChallenges = new Gson().toJson(authorization.getCombinations());
+        String cliSupportedMethods = new Gson().toJson(desiredChallengeCombos);
+        throw new RuntimeException("Failed to find a supportable combination of domain verification challenges. " +
+                "Supported challenge combos by the API: " + apiSupportedChallenges +
+                ", challenge combos supported by the CLI: " + cliSupportedMethods);
+    }
+
+    /**
+     * Performs the ACME DNS 01 Challenge by creating txt records in Route 53
+     *
+     * @param challenge The ACME challenge info with digest
+     * @param domainName The domain name that is being verified
+     * @param hostedZoneId The hosted zone id that has permissions to create dns records for the domain name
+     */
+    protected void doDns01Challenge(Dns01Challenge challenge, String domainName, String hostedZoneId) {
+        String digest = challenge.getDigest();
+        try {
+            String cname = String.format(CHALLENGE_ENTRY_TEMPLATE, domainName);
+            generateChallengeTxtEntry(cname, digest, hostedZoneId);
+            Optional<String> recordValue;
+            do {
+                log.info("Waiting for name: '{}' to have txt record digest value: '{}' before triggering challenge", cname, digest);
+                Thread.sleep(TimeUnit.SECONDS.toMillis(60));
+                recordValue = getTxtRecordValue(cname);
+            } while (! recordValue.isPresent() || ! recordValue.get().equals(String.format("\"%s\"", digest)));
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Failed to complete DNS 01 challenge", e);
+        }
+
+        triggerChallenge(challenge);
+    }
+
+    /**
+     * Triggers the ACME challenge polling for its status to be complete
+     *
+     * @param challenge The challenge that is ready to be triggered
+     */
+    protected void triggerChallenge(Challenge challenge) {
+        try {
+            challenge.trigger();
+
+            // TODO better polling is possible, this can cause infinite loops
+            while (challenge.getStatus() != Status.VALID) {
+                log.info("Waiting for challenge to complete");
+                Thread.sleep(3000);
+                challenge.update();
+            }
+            log.info("challenge accepted");
+        } catch (AcmeException | InterruptedException e) {
+            log.error("failed to trigger and wait for challenge to be accepted", e);
+        }
+    }
+
+    /**
+     * Netty, which is what CMS is using requires the private key to be in PKCS8 format
+     * http://netty.io/wiki/sslcontextbuilder-and-private-key.html
+     */
+    protected void createPKCS8PrivateKeyPemFileFromKeyPair(KeyPair keyPair, File certDir) {
+        try {
+            JcaPKCS8Generator pkcs8Generator = new JcaPKCS8Generator(keyPair.getPrivate(), null);
+            PemObject pemObject = pkcs8Generator.generate();
+            FileWriter fileWriter = new FileWriter(new File(certDir.getAbsolutePath()
+                    + File.separator + DOMAIN_PKCS8_KEY_FILE));
+            try (JcaPEMWriter pemWriter = new JcaPEMWriter(fileWriter)) {
+                pemWriter.writeObject(pemObject);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load private key pem", e);
+        }
+    }
+}

--- a/src/main/java/com/nike/cerberus/service/ConsoleService.java
+++ b/src/main/java/com/nike/cerberus/service/ConsoleService.java
@@ -17,6 +17,7 @@
 package com.nike.cerberus.service;
 
 import com.google.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -44,5 +45,46 @@ public class ConsoleService {
             return System.console().readPassword(format, args);
         }
         return readLine(format, args).toCharArray();
+    }
+
+    public void askUserToProceed(String additionalMessage, DefaultAction defaultAction) {
+        String userInput;
+        try {
+            StringBuilder sb = new StringBuilder();
+            if (StringUtils.isNotBlank(additionalMessage)) {
+                sb.append(additionalMessage).append('\n');
+            }
+            sb.append("Would you like to proceed? ")
+                    .append(defaultAction.isYesDefault() ? "(Y/n)" : "(y/N)")
+                    .append(": ");
+            userInput = readLine(sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to ask user to proceed", e);
+        }
+
+        if (StringUtils.isBlank(userInput) && defaultAction.isYesDefault()) {
+            return;
+        }
+
+        if (StringUtils.isNotBlank(userInput) && (userInput.equalsIgnoreCase("y") || userInput.equalsIgnoreCase("yes"))) {
+            return;
+        }
+
+        throw new RuntimeException("User declined to proceed");
+    }
+
+    public enum DefaultAction {
+        YES(true),
+        NO(false);
+
+        private boolean yesIsDefault;
+
+        protected boolean isYesDefault() {
+            return yesIsDefault;
+        }
+
+        DefaultAction(boolean yesIsDefault) {
+            this.yesIsDefault = yesIsDefault;
+        }
     }
 }

--- a/src/main/java/com/nike/cerberus/store/ConfigStore.java
+++ b/src/main/java/com/nike/cerberus/store/ConfigStore.java
@@ -63,7 +63,6 @@ import static com.nike.cerberus.ConfigConstants.CERT_PART_CA;
 import static com.nike.cerberus.ConfigConstants.CERT_PART_CERT;
 import static com.nike.cerberus.ConfigConstants.CERT_PART_KEY;
 import static com.nike.cerberus.ConfigConstants.CERT_PART_PKCS8_KEY;
-import static com.nike.cerberus.ConfigConstants.CERT_PART_PUBKEY;
 import static com.nike.cerberus.ConfigConstants.CMS_ROLE_ARN_KEY;
 import static com.nike.cerberus.ConfigConstants.HASH_SALT;
 import static com.nike.cerberus.ConfigConstants.JDBC_PASSWORD_KEY;
@@ -333,20 +332,18 @@ public class ConfigStore {
      * @param caContents      CA chain
      * @param certContents    Certificate body
      * @param keyContents     Certificate key
-     * @param pubKeyContents  Certificate public key
      */
     public void storeCert(final StackName stackName,
                           final String certificateName,
                           final String caContents,
                           final String certContents,
                           final String keyContents,
-                          final String pkcs8KeyContents,
-                          final String pubKeyContents) {
+                          final String pkcs8KeyContents) {
+
         saveEncryptedObject(buildCertFilePath(stackName, CERT_PART_CA), caContents);
         saveEncryptedObject(buildCertFilePath(stackName, CERT_PART_CERT), certContents);
         saveEncryptedObject(buildCertFilePath(stackName, CERT_PART_KEY), keyContents);
         saveEncryptedObject(buildCertFilePath(stackName, CERT_PART_PKCS8_KEY), pkcs8KeyContents);
-        saveEncryptedObject(buildCertFilePath(stackName, CERT_PART_PUBKEY), pubKeyContents);
 
         synchronized (envDataLock) {
             final Environment environment = getEnvironmentData();


### PR DESCRIPTION
Adding generate cert command that has an Integration Test that is passing with LetsEncrypt ACME api.

This command just creates the files locally and relies on the existing upload cert command to upload to S3 / IAM. Plan is to possibly stream line this once @sdford's changes get merged and I do the rotate command.

Take a look at the Generate Certs Operation Integration Test for my testing methodology.    