### PR TITLE
Add Command to generate Certificate and Keys using BouncyCastle and ACME Providers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,9 @@ gradle-app.setting
 
 # Python cache
 **/__pycache__/
+/certs/
+build/certs/
+*.pem
+*.key
+*.crt
+*.csr

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -19,7 +19,7 @@ allprojects {
         jcenter()
     }
 
-    def awsSDKVersion = '1.11.155'
+    def awsSDKVersion = '1.11.220'
 
     //noinspection GroovyAssignabilityCheck
     dependencies {
@@ -33,6 +33,8 @@ allprojects {
         compile group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: awsSDKVersion
         compile group: 'com.amazonaws', name: 'aws-java-sdk-sns', version: awsSDKVersion
         compile group: 'com.amazonaws', name: 'aws-java-sdk-lambda', version: awsSDKVersion
+        compile group: 'com.amazonaws', name: 'aws-java-sdk-route53', version: awsSDKVersion
+
 
         compile 'com.nike:vault-client:1.4.1'
         compile 'com.squareup.okhttp3:okhttp:3.3.1'
@@ -57,9 +59,23 @@ allprojects {
         compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.6'
         compile group: 'com.google.code.findbugs', name: 'annotations', version: '3.0.0'
 
+        // Cert Generation
+        compile group: 'dnsjava', name: 'dnsjava', version: '2.1.8'
+        compile group: 'org.shredzone.acme4j', name: 'acme4j-client', version: '0.13'
+        compile group: 'org.shredzone.acme4j', name: 'acme4j-utils', version: '0.13'
+
         testCompile "junit:junit:4.12"
         testCompile ("org.mockito:mockito-core:1.10.19") {
             exclude group: 'org.hamcrest'
         }
+        testCompile 'com.fieldju:commons:1.2.0'
+        testCompile group: 'io.netty', name: 'netty-handler', version: '4.1.16.Final'
+
     }
+
+    configurations.all {
+        // check for updates every build
+        resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+    }
+
 }

--- a/gradle/integration.gradle
+++ b/gradle/integration.gradle
@@ -34,3 +34,9 @@ task integrationTest(type: Test) {
     testClassesDir = sourceSets.integrationTest.output.classesDir
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
+
+integrationTest {
+    testLogging {
+        showStandardStreams = true
+    }
+}

--- a/src/integration-test/java/com/nike/cerberus/operation/core/GenerateCertsOperationIntegrationTest.java
+++ b/src/integration-test/java/com/nike/cerberus/operation/core/GenerateCertsOperationIntegrationTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.operation.core;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClient;
+import com.amazonaws.services.identitymanagement.model.DeleteServerCertificateRequest;
+import com.amazonaws.services.identitymanagement.model.UploadServerCertificateRequest;
+import com.amazonaws.services.identitymanagement.model.UploadServerCertificateResult;
+import com.amazonaws.services.route53.AmazonRoute53Client;
+import com.google.common.collect.ImmutableSet;
+import com.nike.cerberus.command.core.GenerateCertsCommand;
+import com.nike.cerberus.domain.EnvironmentMetadata;
+import com.nike.cerberus.service.CertificateService;
+import com.nike.cerberus.service.ConsoleService;
+import io.netty.handler.ssl.SslContextBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.UUID;
+
+import static com.fieldju.commons.PropUtils.getPropWithDefaultValue;
+import static com.fieldju.commons.PropUtils.getRequiredProperty;
+import static com.nike.cerberus.service.CertificateService.CERT_CHAIN_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_CERT_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_CSR_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_FULL_CERT_WITH_CHAIN_CRT_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_PKCS1_KEY_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_PKCS8_KEY_FILE;
+import static com.nike.cerberus.service.CertificateService.PUB_KEY_FILE;
+import static com.nike.cerberus.service.CertificateService.USER_KEY_FILE;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.contains;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * This integration test will generate certs using an provided ACME api and test that the certs are usable my an AWS ALB and Netty's SSL Context Builder.
+ *
+ * Running this Integration Test will automatically accept the TOS of the ACME provider if present.
+ * By Running this test you are agreeing with the Terms of Service of the ACME Provider API you provide.
+ *
+ * Required Props (can be set via env or system props)
+ *
+ * CERT_GEN_TEST_DOMAIN: A domain that will be used as the common name for the generated certs,
+ *      you must also provide a hosted zone id that can create records for this domain.
+ *
+ * CERT_GEN_HOSTED_ZONE_ID: The hosted zone id that can create records for CERT_GEN_TEST_DOMAIN
+ *
+ * CERT_GEN_CONTACT_EMAIL: The email to use as the contact when generating the cert
+ *
+ * Optional Props
+ *
+ * CERT_GEN_ACME_API: the ACME api to test against, defaults to 'acme://letsencrypt.org/staging'
+ *
+ * EX: CERT_GEN_TEST_DOMAIN=cerberus-oss.io CERT_GEN_HOSTED_ZONE_ID=123123 CERT_GEN_CONTACT_EMAIL=justin.field@nike.com ./gradlew clean integrationTest -DintegrationTest.debug -DintegrationTest.single=GenerateCertsOperationIntegrationTest
+ *
+ */
+public class GenerateCertsOperationIntegrationTest {
+
+    public static String CERT_DIR = "build/certs/";
+
+    @Mock
+    private GenerateCertsCommand command;
+
+    @Mock
+    private ConsoleService consoleService;
+
+    @Mock
+    private EnvironmentMetadata environmentMetadata;
+
+    private GenerateCertsOperation operation;
+
+    private File certDir;
+
+    @Before
+    public void before() {
+        initMocks(this);
+
+        CertificateService certificateService = new CertificateService(consoleService,
+                AmazonRoute53Client.builder().withRegion("us-west-2").build());
+
+        operation = new GenerateCertsOperation(certificateService, environmentMetadata, consoleService);
+
+        certDir = new File(CERT_DIR);
+    }
+
+    @Test
+    public void test_that_command_generates_valid_certs() throws IOException {
+        when(environmentMetadata.getName()).thenReturn("integration-test");
+        when(environmentMetadata.getRegionName()).thenReturn("us-west-2");
+        when(command.getBaseDomainName()).thenReturn(getRequiredProperty("CERT_GEN_TEST_DOMAIN",
+                "CERT_GEN_TEST_DOMAIN is a required env or system prop and must be a domain that you have a" +
+                        " hosted zone for that can create records"));
+        when(command.getHostedZoneId()).thenReturn(getRequiredProperty("CERT_GEN_HOSTED_ZONE_ID",
+                "The hosted zone id that can create records for CERT_GEN_TEST_DOMAIN"));
+        when(consoleService.readLine(contains("Would you like to proceed?"))).thenReturn("y");
+        when(command.enableLetsEncryptCertfix()).thenReturn(true);
+        when(command.getCertDir()).thenReturn(certDir.getAbsolutePath());
+        when(consoleService.readLine(contains("accept")))
+                .thenReturn("i accept");
+        when(command.getAcmeApiUrl()).thenReturn(getPropWithDefaultValue("CERT_GEN_ACME_API",
+                "acme://letsencrypt.org/staging"));
+        when(command.getContactEmail()).thenReturn(getRequiredProperty("CERT_GEN_CONTACT_EMAIL",
+                "The email contact to use when generating the cert"));
+
+        operation.run(command);
+
+        ImmutableSet.of(
+                USER_KEY_FILE,
+                DOMAIN_PKCS1_KEY_FILE,
+                DOMAIN_PKCS8_KEY_FILE,
+                DOMAIN_CSR_FILE,
+                DOMAIN_FULL_CERT_WITH_CHAIN_CRT_FILE,
+                DOMAIN_CERT_FILE,
+                CERT_CHAIN_FILE,
+                PUB_KEY_FILE
+        ).forEach(expectedFileName -> {
+            File expectedFile = new File(certDir.getAbsolutePath() + File.separator + expectedFileName);
+            assertTrue("The expected file should exist after running the generate certs command", expectedFile.exists());
+        });
+
+        // test that the certs are usable by and ALB
+        assertThatCertsAreUsableByAws();
+
+        // test that the PKCS8 Private key and ACME generated cert are loadable by CMS
+        assertThatCertsAreUsableByCms();
+
+        System.out.println("The Keys and Certificates where properly generated and passed validation");
+    }
+
+    private void assertThatCertsAreUsableByAws() throws IOException {
+        String uuid = UUID.randomUUID().toString();
+        AmazonIdentityManagement amazonIdentityManagement = AmazonIdentityManagementClient.builder().withRegion(Regions.DEFAULT_REGION).build();
+        final UploadServerCertificateRequest request = new UploadServerCertificateRequest()
+                .withServerCertificateName("cert-gen-integration-test-" + uuid)
+                .withPath("/cert-gen-integration-test/" + uuid + "/")
+                .withCertificateBody(new String(Files.readAllBytes((new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CERT_FILE).toPath()))))
+                .withCertificateChain(new String(Files.readAllBytes((new File(certDir.getAbsolutePath() + File.separator + CERT_CHAIN_FILE).toPath()))))
+                .withPrivateKey(new String(Files.readAllBytes(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_PKCS1_KEY_FILE).toPath())));
+
+        final UploadServerCertificateResult result = amazonIdentityManagement.uploadServerCertificate(request);
+
+        assertTrue(StringUtils.isNotBlank(result.getServerCertificateMetadata().getArn()));
+
+        amazonIdentityManagement.deleteServerCertificate(
+                new DeleteServerCertificateRequest()
+                        .withServerCertificateName(result.getServerCertificateMetadata().getServerCertificateName())
+        );
+    }
+
+    private void assertThatCertsAreUsableByCms() {
+        String[] cmsSupportedProtocols = new String[] {
+                "TLSv1.2"
+        };
+
+        try {
+            SslContextBuilder.forServer(
+                    new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CERT_FILE),
+                    new File(certDir.getAbsolutePath() + File.separator + DOMAIN_PKCS8_KEY_FILE)
+            ).protocols(cmsSupportedProtocols).build();
+        } catch (Exception e) {
+            fail("Failed to generate the SSL Context that CMS uses to validate Cert and PKCS8 private key. Reason: " + e.getMessage());
+        }
+    }
+
+}

--- a/src/integration-test/java/com/nike/cerberus/operation/core/GenerateCertsOperationIntegrationTest.java
+++ b/src/integration-test/java/com/nike/cerberus/operation/core/GenerateCertsOperationIntegrationTest.java
@@ -41,13 +41,13 @@ import java.util.UUID;
 
 import static com.fieldju.commons.PropUtils.getPropWithDefaultValue;
 import static com.fieldju.commons.PropUtils.getRequiredProperty;
-import static com.nike.cerberus.service.CertificateService.CERT_CHAIN_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_CERT_CHAIN_FILE;
 import static com.nike.cerberus.service.CertificateService.DOMAIN_CERT_FILE;
 import static com.nike.cerberus.service.CertificateService.DOMAIN_CSR_FILE;
 import static com.nike.cerberus.service.CertificateService.DOMAIN_FULL_CERT_WITH_CHAIN_CRT_FILE;
 import static com.nike.cerberus.service.CertificateService.DOMAIN_PKCS1_KEY_FILE;
 import static com.nike.cerberus.service.CertificateService.DOMAIN_PKCS8_KEY_FILE;
-import static com.nike.cerberus.service.CertificateService.PUB_KEY_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_PUBLIC_KEY_FILE;
 import static com.nike.cerberus.service.CertificateService.USER_KEY_FILE;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -134,8 +134,8 @@ public class GenerateCertsOperationIntegrationTest {
                 DOMAIN_CSR_FILE,
                 DOMAIN_FULL_CERT_WITH_CHAIN_CRT_FILE,
                 DOMAIN_CERT_FILE,
-                CERT_CHAIN_FILE,
-                PUB_KEY_FILE
+                DOMAIN_CERT_CHAIN_FILE,
+                DOMAIN_PUBLIC_KEY_FILE
         ).forEach(expectedFileName -> {
             File expectedFile = new File(certDir.getAbsolutePath() + File.separator + expectedFileName);
             assertTrue("The expected file should exist after running the generate certs command", expectedFile.exists());
@@ -157,7 +157,7 @@ public class GenerateCertsOperationIntegrationTest {
                 .withServerCertificateName("cert-gen-integration-test-" + uuid)
                 .withPath("/cert-gen-integration-test/" + uuid + "/")
                 .withCertificateBody(new String(Files.readAllBytes((new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CERT_FILE).toPath()))))
-                .withCertificateChain(new String(Files.readAllBytes((new File(certDir.getAbsolutePath() + File.separator + CERT_CHAIN_FILE).toPath()))))
+                .withCertificateChain(new String(Files.readAllBytes((new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CERT_CHAIN_FILE).toPath()))))
                 .withPrivateKey(new String(Files.readAllBytes(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_PKCS1_KEY_FILE).toPath())));
 
         final UploadServerCertificateResult result = amazonIdentityManagement.uploadServerCertificate(request);

--- a/src/main/java/com/nike/cerberus/cli/CerberusRunner.java
+++ b/src/main/java/com/nike/cerberus/cli/CerberusRunner.java
@@ -32,6 +32,7 @@ import com.nike.cerberus.command.cms.CreateCmsCmkCommand;
 import com.nike.cerberus.command.cms.CreateCmsConfigCommand;
 import com.nike.cerberus.command.cms.UpdateCmsConfigCommand;
 import com.nike.cerberus.command.core.CreateCerberusBackupCommand;
+import com.nike.cerberus.command.core.GenerateCertsCommand;
 import com.nike.cerberus.command.core.RollingRebootWithHealthCheckCommand;
 import com.nike.cerberus.command.core.ViewConfigCommand;
 import com.nike.cerberus.command.core.CreateBaseCommand;
@@ -170,6 +171,7 @@ public class CerberusRunner {
         registerCommand(new RollingRebootWithHealthCheckCommand());
         registerCommand(new CreateCerberusBackupCommand());
         registerCommand(new SetBackupAdminPrincipalsCommand());
+        registerCommand(new GenerateCertsCommand());
     }
 
     /**

--- a/src/main/java/com/nike/cerberus/command/core/GenerateCertsCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/GenerateCertsCommand.java
@@ -39,32 +39,25 @@ public class GenerateCertsCommand implements Command {
             "through out the system, using an ACME provider such as LetsEncrypt";
 
     public static final String BASE_DOMAIN_LONG_ARG = "--base-domain";
-    public static final String BASE_DOMAIN_SHORT_ARG = "-d";
 
     public static final String HOSTED_ZONE_ID_LONG_ARG = "--hosted-zone-id";
-    public static final String HOSTED_ZONE_ID_SHORT_ARG = "-h";
 
     public static final String ADDITIONAL_SUBJECT_ALT_NAME_LONG_ARG = "--additional-subject-alternative-name";
-    public static final String ADDITIONAL_SUBJECT_ALT_NAME_SHORT_ARG = "-a";
 
     public static final String ENABLE_LE_CERTFIX_LONG_ARG = "--enable-letsecrypt-certfix";
-    public static final String ENABLE_LE_CERTFIX_SHORT_ARG = "-elec";
 
     public static final String CERT_FOLDER_LONG_ARG = "--cert-dir";
-    public static final String CERT_FOLDER_SHORT_ARG = "-cd";
 
     public static final String ACME_API_LONG_ARG = "--acme-api-url";
-    public static final String ACME_API_SHORT_ARG = "-u";
+
+    public static final String CONTACT_EMAIL_LONG_ARG = "--contact-email";
 
     public static final String LETS_ENCRYPT_ACME_API_URI = "acme://letsencrypt.org";
 
-    public static final String CONTACT_EMAIL_LONG_ARG = "--contact-email";
-    public static final String CONTACT_EMAIL_SHORT_ARG = "-c";
 
     @Parameter(
             names = {
-                    BASE_DOMAIN_LONG_ARG,
-                    BASE_DOMAIN_SHORT_ARG
+                    BASE_DOMAIN_LONG_ARG
             },
             description = "The base domain for the environment that this command will use to generate the following " +
                     "subject name {env}.{base-domain} and with the following subject alternative name {env}.{region}.{base-domain}\n" +
@@ -82,8 +75,7 @@ public class GenerateCertsCommand implements Command {
 
     @Parameter(
             names = {
-                    HOSTED_ZONE_ID_LONG_ARG,
-                    HOSTED_ZONE_ID_SHORT_ARG
+                    HOSTED_ZONE_ID_LONG_ARG
             },
             description = "The AWS Route 53 hosted zone id that is configured to create records for the base domain",
             required = true
@@ -96,8 +88,7 @@ public class GenerateCertsCommand implements Command {
 
     @Parameter(
             names = {
-                    ADDITIONAL_SUBJECT_ALT_NAME_LONG_ARG,
-                    ADDITIONAL_SUBJECT_ALT_NAME_SHORT_ARG
+                    ADDITIONAL_SUBJECT_ALT_NAME_LONG_ARG
             },
             description = "Alternative subject names, this should be any additional cnames that need to be secured. such as "
     )
@@ -109,8 +100,7 @@ public class GenerateCertsCommand implements Command {
 
     @Parameter(
             names = {
-                    ENABLE_LE_CERTFIX_LONG_ARG,
-                    ENABLE_LE_CERTFIX_SHORT_ARG
+                    ENABLE_LE_CERTFIX_LONG_ARG
             },
             description = "This command uses the acme4j client to communicate with the ACME server, " +
                     "it supports uses a hardcoded letsencrypt cert to get around ssl errors, you can use this " +
@@ -125,10 +115,9 @@ public class GenerateCertsCommand implements Command {
 
     @Parameter(
             names = {
-                    CERT_FOLDER_LONG_ARG,
-                    CERT_FOLDER_SHORT_ARG
+                    CERT_FOLDER_LONG_ARG
             },
-            description = "The cert folder to store the generated files",
+            description = "A local writable folder to store the generated key and cert files",
             required = true
     )
     private String certDir;
@@ -139,8 +128,7 @@ public class GenerateCertsCommand implements Command {
 
     @Parameter(
             names = {
-                    ACME_API_LONG_ARG,
-                    ACME_API_SHORT_ARG
+                    ACME_API_LONG_ARG
             },
             description = "The ACME API Url to use, This can be any ACME provider like LetsEncrypt: "  + LETS_ENCRYPT_ACME_API_URI,
             required = true
@@ -153,8 +141,7 @@ public class GenerateCertsCommand implements Command {
 
     @Parameter(
             names = {
-                    CONTACT_EMAIL_LONG_ARG,
-                    CONTACT_EMAIL_SHORT_ARG
+                    CONTACT_EMAIL_LONG_ARG
             },
             description = "The email contact to use when creating the certs",
             required = true

--- a/src/main/java/com/nike/cerberus/command/core/GenerateCertsCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/GenerateCertsCommand.java
@@ -51,7 +51,7 @@ public class GenerateCertsCommand implements Command {
     public static final String ENABLE_LE_CERTFIX_SHORT_ARG = "-elec";
 
     public static final String CERT_FOLDER_LONG_ARG = "--cert-dir";
-    public static final String CERT_FOLDER_SHORT_ARG = "-c";
+    public static final String CERT_FOLDER_SHORT_ARG = "-cd";
 
     public static final String ACME_API_LONG_ARG = "--acme-api-url";
     public static final String ACME_API_SHORT_ARG = "-u";

--- a/src/main/java/com/nike/cerberus/command/core/GenerateCertsCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/GenerateCertsCommand.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.command.core;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.nike.cerberus.command.Command;
+import com.nike.cerberus.operation.Operation;
+import com.nike.cerberus.operation.core.GenerateCertsOperation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.nike.cerberus.command.core.GenerateCertsCommand.COMMAND_DESCRIPTION;
+import static com.nike.cerberus.command.core.GenerateCertsCommand.COMMAND_NAME;
+
+@Parameters(
+        commandNames = COMMAND_NAME,
+        commandDescription = COMMAND_DESCRIPTION
+)
+public class GenerateCertsCommand implements Command {
+
+    public static final String COMMAND_NAME = "generate-certs";
+    public static final String COMMAND_DESCRIPTION = "Generates the TLS certificates needed to enable https " +
+            "through out the system, using an ACME provider such as LetsEncrypt";
+
+    public static final String BASE_DOMAIN_LONG_ARG = "--base-domain";
+    public static final String BASE_DOMAIN_SHORT_ARG = "-d";
+
+    public static final String HOSTED_ZONE_ID_LONG_ARG = "--hosted-zone-id";
+    public static final String HOSTED_ZONE_ID_SHORT_ARG = "-h";
+
+    public static final String ADDITIONAL_SUBJECT_ALT_NAME_LONG_ARG = "--additional-subject-alternative-name";
+    public static final String ADDITIONAL_SUBJECT_ALT_NAME_SHORT_ARG = "-a";
+
+    public static final String ENABLE_LE_CERTFIX_LONG_ARG = "--enable-letsecrypt-certfix";
+    public static final String ENABLE_LE_CERTFIX_SHORT_ARG = "-elec";
+
+    public static final String CERT_FOLDER_LONG_ARG = "--cert-dir";
+    public static final String CERT_FOLDER_SHORT_ARG = "-c";
+
+    public static final String ACME_API_LONG_ARG = "--acme-api-url";
+    public static final String ACME_API_SHORT_ARG = "-u";
+
+    public static final String LETS_ENCRYPT_ACME_API_URI = "acme://letsencrypt.org";
+
+    public static final String CONTACT_EMAIL_LONG_ARG = "--contact-email";
+    public static final String CONTACT_EMAIL_SHORT_ARG = "-c";
+
+    @Parameter(
+            names = {
+                    BASE_DOMAIN_LONG_ARG,
+                    BASE_DOMAIN_SHORT_ARG
+            },
+            description = "The base domain for the environment that this command will use to generate the following " +
+                    "subject name {env}.{base-domain} and with the following subject alternative name {env}.{region}.{base-domain}\n" +
+                    "ex: cerberus -e demo -r us-west-2 generate-certs -d cerberus-oss.io would make a cert for demo.cerberus-oss.io " +
+                    "with a sans of demo.us-west-2.cerberus-oss.io so that we can create a CNAME record for " +
+                    "demo.cerberus-oss.io that will point to an ALB in us-west-2 with a CNAME record of " +
+                    "demo.us-west-2.cerberus-oss.io and the cert will be valid for both",
+            required = true
+    )
+    private String baseDomainName;
+
+    public String getBaseDomainName() {
+        return baseDomainName;
+    }
+
+    @Parameter(
+            names = {
+                    HOSTED_ZONE_ID_LONG_ARG,
+                    HOSTED_ZONE_ID_SHORT_ARG
+            },
+            description = "The AWS Route 53 hosted zone id that is configured to create records for the base domain",
+            required = true
+    )
+    private String hostedZoneId;
+
+    public String getHostedZoneId() {
+        return hostedZoneId;
+    }
+
+    @Parameter(
+            names = {
+                    ADDITIONAL_SUBJECT_ALT_NAME_LONG_ARG,
+                    ADDITIONAL_SUBJECT_ALT_NAME_SHORT_ARG
+            },
+            description = "Alternative subject names, this should be any additional cnames that need to be secured. such as "
+    )
+    private List<String> subjectAlternativeNames = new ArrayList<>();
+
+    public List<String> getSubjectAlternativeNames() {
+        return subjectAlternativeNames;
+    }
+
+    @Parameter(
+            names = {
+                    ENABLE_LE_CERTFIX_LONG_ARG,
+                    ENABLE_LE_CERTFIX_SHORT_ARG
+            },
+            description = "This command uses the acme4j client to communicate with the ACME server, " +
+                    "it supports uses a hardcoded letsencrypt cert to get around ssl errors, you can use this " +
+                    "flag if your truststore is not configured to trust LE Certs, which can be found " +
+                    " here: https://letsencrypt.org/certificates/"
+    )
+    private boolean EnableLetsEncryptCertfix = false;
+
+    public boolean enableLetsEncryptCertfix() {
+        return EnableLetsEncryptCertfix;
+    }
+
+    @Parameter(
+            names = {
+                    CERT_FOLDER_LONG_ARG,
+                    CERT_FOLDER_SHORT_ARG
+            },
+            description = "The cert folder to store the generated files",
+            required = true
+    )
+    private String certDir;
+
+    public String getCertDir() {
+        return certDir;
+    }
+
+    @Parameter(
+            names = {
+                    ACME_API_LONG_ARG,
+                    ACME_API_SHORT_ARG
+            },
+            description = "The ACME API Url to use, This can be any ACME provider like LetsEncrypt: "  + LETS_ENCRYPT_ACME_API_URI,
+            required = true
+    )
+    private String acmeApiUrl;
+
+    public String getAcmeApiUrl() {
+        return acmeApiUrl;
+    }
+
+    @Parameter(
+            names = {
+                    CONTACT_EMAIL_LONG_ARG,
+                    CONTACT_EMAIL_SHORT_ARG
+            },
+            description = "The email contact to use when creating the certs",
+            required = true
+    )
+    private String contactEmail;
+
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    @Override
+    public String getCommandName() {
+        return COMMAND_NAME;
+    }
+
+    @Override
+    public Class<? extends Operation<?>> getOperationClass() {
+        return GenerateCertsOperation.class;
+    }
+}

--- a/src/main/java/com/nike/cerberus/command/core/GenerateCertsCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/GenerateCertsCommand.java
@@ -34,7 +34,7 @@ import static com.nike.cerberus.command.core.GenerateCertsCommand.COMMAND_NAME;
 )
 public class GenerateCertsCommand implements Command {
 
-    public static final String COMMAND_NAME = "generate-certs";
+    public static final String COMMAND_NAME = "generate-certificates";
     public static final String COMMAND_DESCRIPTION = "Generates the TLS certificates needed to enable https " +
             "through out the system, using an ACME provider such as LetsEncrypt";
 
@@ -46,7 +46,7 @@ public class GenerateCertsCommand implements Command {
 
     public static final String ENABLE_LE_CERTFIX_LONG_ARG = "--enable-letsecrypt-certfix";
 
-    public static final String CERT_FOLDER_LONG_ARG = "--cert-dir";
+    public static final String CERT_FOLDER_LONG_ARG = "--local-certificate-directory";
 
     public static final String ACME_API_LONG_ARG = "--acme-api-url";
 
@@ -61,10 +61,10 @@ public class GenerateCertsCommand implements Command {
             },
             description = "The base domain for the environment that this command will use to generate the following " +
                     "subject name {env}.{base-domain} and with the following subject alternative name {env}.{region}.{base-domain}\n" +
-                    "ex: cerberus -e demo -r us-west-2 generate-certs -d cerberus-oss.io would make a cert for demo.cerberus-oss.io " +
-                    "with a sans of demo.us-west-2.cerberus-oss.io so that we can create a CNAME record for " +
-                    "demo.cerberus-oss.io that will point to an ALB in us-west-2 with a CNAME record of " +
-                    "demo.us-west-2.cerberus-oss.io and the cert will be valid for both",
+                    "ex: cerberus -e demo -r us-west-2 generate-certificates --base-domain cerberus.example would make a cert for demo.cerberus.example " +
+                    "with a sans of demo.us-west-2.cerberus.example so that we can create a CNAME record for " +
+                    "demo.cerberus.example that will point to an ALB in us-west-2 with a CNAME record of " +
+                    "demo.us-west-2.cerberus.example and the cert will be valid for both",
             required = true
     )
     private String baseDomainName;
@@ -104,7 +104,7 @@ public class GenerateCertsCommand implements Command {
             },
             description = "This command uses the acme4j client to communicate with the ACME server, " +
                     "it supports uses a hardcoded letsencrypt cert to get around ssl errors, you can use this " +
-                    "flag if your truststore is not configured to trust LE Certs, which can be found " +
+                    "flag if your truststore is not configured to trust LE certificates, which can be found " +
                     " here: https://letsencrypt.org/certificates/"
     )
     private boolean EnableLetsEncryptCertfix = false;
@@ -130,7 +130,7 @@ public class GenerateCertsCommand implements Command {
             names = {
                     ACME_API_LONG_ARG
             },
-            description = "The ACME API Url to use, This can be any ACME provider like LetsEncrypt: "  + LETS_ENCRYPT_ACME_API_URI,
+            description = "The ACME provider API URL to use, e.g. Let's Encrypt: "  + LETS_ENCRYPT_ACME_API_URI,
             required = true
     )
     private String acmeApiUrl;
@@ -143,7 +143,7 @@ public class GenerateCertsCommand implements Command {
             names = {
                     CONTACT_EMAIL_LONG_ARG
             },
-            description = "The email contact to use when creating the certs",
+            description = "The email contact to use when creating the certificates",
             required = true
     )
     private String contactEmail;

--- a/src/main/java/com/nike/cerberus/operation/core/GenerateCertsOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/GenerateCertsOperation.java
@@ -87,7 +87,7 @@ public class GenerateCertsOperation implements Operation<GenerateCertsCommand> {
             // check that we can write to the provided dir
             FileUtils.forceMkdir(certDir);
             if (! certDir.isDirectory() || ! certDir.canWrite()) {
-                throw new RuntimeException("Cert dir file is not a directory or is not writable, path: " + certDir.getAbsolutePath());
+                throw new RuntimeException("The certificate directory is not a directory or is not writable, path: " + certDir.getAbsolutePath());
             }
 
             // generate the certs

--- a/src/main/java/com/nike/cerberus/operation/core/GenerateCertsOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/GenerateCertsOperation.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.operation.core;
+
+import com.nike.cerberus.command.core.GenerateCertsCommand;
+import com.nike.cerberus.domain.EnvironmentMetadata;
+import com.nike.cerberus.operation.Operation;
+import com.nike.cerberus.service.CertificateService;
+import com.nike.cerberus.service.ConsoleService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.nike.cerberus.service.ConsoleService.DefaultAction.NO;
+
+/**
+ * Operation that uses the cert service to generate the certificates needed to enable https in a Cerberus Env.
+ */
+public class GenerateCertsOperation implements Operation<GenerateCertsCommand> {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final CertificateService certService;
+    private final EnvironmentMetadata environmentMetadata;
+    private final ConsoleService consoleService;
+
+    @Inject
+    public GenerateCertsOperation(CertificateService certService,
+                                  EnvironmentMetadata environmentMetadata,
+                                  ConsoleService consoleService) {
+
+        this.certService = certService;
+        this.environmentMetadata = environmentMetadata;
+        this.consoleService = consoleService;
+    }
+
+    @SuppressFBWarnings(
+            value = "REC_CATCH_EXCEPTION",
+            justification = "I do not want to catch 1000 individual exceptions"
+    )
+    @Override
+    public void run(GenerateCertsCommand command) {
+        // The common name ex: demo.cerberus.io
+        String commonName = String.format("%s.%s", environmentMetadata.getName(), command.getBaseDomainName());
+        // The region specific subject alternate name. EX demo.us-west-2.ceberus.io
+        String regionSpecificSAN = String.format("%s.%s.%s",
+                environmentMetadata.getName(), environmentMetadata.getRegionName(), command.getBaseDomainName());
+
+        Set<String> subjectAlternativeNames = new HashSet<>();
+        subjectAlternativeNames.addAll(command.getSubjectAlternativeNames()); // add any additional SANs to the SAN set
+        subjectAlternativeNames.add(regionSpecificSAN); // add the default region specific san
+
+        // confirm with user
+        consoleService.askUserToProceed(String.format("Preparing to generate certs with Common Name: %s and Subject Alternative Names: %s",
+                        commonName, String.join(", ", subjectAlternativeNames)), NO);
+
+        // Enable the use of the hard coded lets encrypt cert if enabled
+        if (command.enableLetsEncryptCertfix()) {
+            log.warn("Setting acme4j.le.certfix system property to 'true', this only works if you use the special acme:// lets encrypt addr. See: https://shredzone.org/maven/acme4j/usage/session.html and https://shredzone.org/maven/acme4j/provider.html");
+            System.setProperty("acme4j.le.certfix", "true");
+        }
+
+        try {
+            // Use a temp dir or local dir if provided
+            File certDir = new File(command.getCertDir());
+
+            // check that we can write to the provided dir
+            FileUtils.forceMkdir(certDir);
+            if (! certDir.isDirectory() || ! certDir.canWrite()) {
+                throw new RuntimeException("Cert dir file is not a directory or is not writable, path: " + certDir.getAbsolutePath());
+            }
+
+            // generate the certs
+            certService.generateCerts(
+                    certDir,
+                    command.getAcmeApiUrl(),
+                    commonName,
+                    subjectAlternativeNames,
+                    command.getHostedZoneId(),
+                    command.getContactEmail()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate certs", e);
+        }
+    }
+
+    @Override
+    public boolean isRunnable(GenerateCertsCommand command) {
+        return true;
+    }
+}

--- a/src/main/java/com/nike/cerberus/operation/core/UploadCertFilesOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/UploadCertFilesOperation.java
@@ -18,11 +18,11 @@ package com.nike.cerberus.operation.core;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.nike.cerberus.command.core.UploadCertFilesCommand;
 import com.nike.cerberus.domain.EnvironmentMetadata;
 import com.nike.cerberus.domain.environment.StackName;
 import com.nike.cerberus.operation.Operation;
+import com.nike.cerberus.service.CertificateService;
 import com.nike.cerberus.service.IdentityManagementService;
 import com.nike.cerberus.store.ConfigStore;
 import com.nike.cerberus.util.UuidSupplier;
@@ -43,12 +43,19 @@ import java.util.Set;
  */
 public class UploadCertFilesOperation implements Operation<UploadCertFilesCommand> {
 
-    private static final String CA_FILE_NAME = "ca.pem";
-    private static final String CERT_FILE_NAME = "cert.pem";
-    private static final String KEY_FILE_NAME = "key.pem";
-    private static final String PKCS8_KEY_FILE_NAME = "pkcs8-key.pem";
-    private static final String PUB_KEY_FILE_NAME = "pubkey.pem";
-    public static final Set<String> EXPECTED_FILE_NAMES = ImmutableSet.of(CA_FILE_NAME, CERT_FILE_NAME, KEY_FILE_NAME, PKCS8_KEY_FILE_NAME, PUB_KEY_FILE_NAME);
+    private static final String CHAIN_FILE_NAME = CertificateService.CERT_CHAIN_FILE;
+    private static final String CERT_FILE_NAME = CertificateService.DOMAIN_CERT_FILE;
+    private static final String PKCS1_KEY_FILE_NAME = CertificateService.DOMAIN_PKCS1_KEY_FILE;
+    private static final String PKCS8_KEY_FILE_NAME = CertificateService.DOMAIN_PKCS8_KEY_FILE;
+    private static final String PUB_KEY_FILE_NAME = CertificateService.PUB_KEY_FILE;
+
+    public static final Set<String> EXPECTED_FILE_NAMES = ImmutableSet.of(
+            CHAIN_FILE_NAME,
+            CERT_FILE_NAME,
+            PKCS1_KEY_FILE_NAME,
+            PKCS8_KEY_FILE_NAME,
+            PUB_KEY_FILE_NAME
+    );
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -75,9 +82,9 @@ public class UploadCertFilesOperation implements Operation<UploadCertFilesComman
     public void run(final UploadCertFilesCommand command) {
         final StackName stackName = command.getStackName();
         final Path certPath = command.getCertPath();
-        final String caContents = getFileContents(certPath, CA_FILE_NAME);
+        final String caContents = getFileContents(certPath, CHAIN_FILE_NAME);
         final String certContents = getFileContents(certPath, CERT_FILE_NAME);
-        final String keyContents = getFileContents(certPath, KEY_FILE_NAME);
+        final String keyContents = getFileContents(certPath, PKCS1_KEY_FILE_NAME);
         final String pkcs8KeyContents = getFileContents(certPath, PKCS8_KEY_FILE_NAME);
         final String pubKeyContents = getFileContents(certPath, PUB_KEY_FILE_NAME);
         final String certificateName = stackName.getName() + "_" + uuidSupplier.get();
@@ -127,6 +134,6 @@ public class UploadCertFilesOperation implements Operation<UploadCertFilesComman
     }
 
     private String getPath() {
-        return "/cloudfront/cerberus/" + environmentMetadata.getName() + "/";
+        return "/cerberus/" + environmentMetadata.getName() + "/";
     }
 }

--- a/src/main/java/com/nike/cerberus/operation/core/UploadCertFilesOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/UploadCertFilesOperation.java
@@ -38,23 +38,23 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 
+import static com.nike.cerberus.service.CertificateService.DOMAIN_CERT_CHAIN_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_CERT_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_PKCS1_KEY_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_PKCS8_KEY_FILE;
+import static com.nike.cerberus.service.CertificateService.DOMAIN_PUBLIC_KEY_FILE;
+
 /**
  * Handles uploading of certificate files to IAM and the config store.
  */
 public class UploadCertFilesOperation implements Operation<UploadCertFilesCommand> {
 
-    private static final String CHAIN_FILE_NAME = CertificateService.CERT_CHAIN_FILE;
-    private static final String CERT_FILE_NAME = CertificateService.DOMAIN_CERT_FILE;
-    private static final String PKCS1_KEY_FILE_NAME = CertificateService.DOMAIN_PKCS1_KEY_FILE;
-    private static final String PKCS8_KEY_FILE_NAME = CertificateService.DOMAIN_PKCS8_KEY_FILE;
-    private static final String PUB_KEY_FILE_NAME = CertificateService.PUB_KEY_FILE;
-
     public static final Set<String> EXPECTED_FILE_NAMES = ImmutableSet.of(
-            CHAIN_FILE_NAME,
-            CERT_FILE_NAME,
-            PKCS1_KEY_FILE_NAME,
-            PKCS8_KEY_FILE_NAME,
-            PUB_KEY_FILE_NAME
+            DOMAIN_CERT_CHAIN_FILE,
+            DOMAIN_CERT_FILE,
+            DOMAIN_PKCS1_KEY_FILE,
+            DOMAIN_PKCS8_KEY_FILE,
+            DOMAIN_PUBLIC_KEY_FILE
     );
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -82,11 +82,11 @@ public class UploadCertFilesOperation implements Operation<UploadCertFilesComman
     public void run(final UploadCertFilesCommand command) {
         final StackName stackName = command.getStackName();
         final Path certPath = command.getCertPath();
-        final String caContents = getFileContents(certPath, CHAIN_FILE_NAME);
-        final String certContents = getFileContents(certPath, CERT_FILE_NAME);
-        final String keyContents = getFileContents(certPath, PKCS1_KEY_FILE_NAME);
-        final String pkcs8KeyContents = getFileContents(certPath, PKCS8_KEY_FILE_NAME);
-        final String pubKeyContents = getFileContents(certPath, PUB_KEY_FILE_NAME);
+        final String caContents = getFileContents(certPath, DOMAIN_CERT_CHAIN_FILE);
+        final String certContents = getFileContents(certPath, DOMAIN_CERT_FILE);
+        final String keyContents = getFileContents(certPath, DOMAIN_PKCS1_KEY_FILE);
+        final String pkcs8KeyContents = getFileContents(certPath, DOMAIN_PKCS8_KEY_FILE);
+        final String pubKeyContents = getFileContents(certPath, DOMAIN_PUBLIC_KEY_FILE);
         final String certificateName = stackName.getName() + "_" + uuidSupplier.get();
 
         logger.info("Uploading certificate to IAM for {}, with name of {}.", stackName.getName(), certificateName);

--- a/src/main/java/com/nike/cerberus/service/CertificateService.java
+++ b/src/main/java/com/nike/cerberus/service/CertificateService.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.service;
+
+import com.amazonaws.services.route53.AmazonRoute53;
+import com.amazonaws.services.route53.model.Change;
+import com.amazonaws.services.route53.model.ChangeAction;
+import com.amazonaws.services.route53.model.ChangeBatch;
+import com.amazonaws.services.route53.model.ChangeResourceRecordSetsRequest;
+import com.amazonaws.services.route53.model.RRType;
+import com.amazonaws.services.route53.model.ResourceRecord;
+import com.amazonaws.services.route53.model.ResourceRecordSet;
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.lang3.StringUtils;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.shredzone.acme4j.Authorization;
+import org.shredzone.acme4j.Certificate;
+import org.shredzone.acme4j.Registration;
+import org.shredzone.acme4j.RegistrationBuilder;
+import org.shredzone.acme4j.Session;
+import org.shredzone.acme4j.Status;
+import org.shredzone.acme4j.challenge.Challenge;
+import org.shredzone.acme4j.challenge.Dns01Challenge;
+import org.shredzone.acme4j.exception.AcmeConflictException;
+import org.shredzone.acme4j.exception.AcmeException;
+import org.shredzone.acme4j.util.CSRBuilder;
+import org.shredzone.acme4j.util.CertificateUtils;
+import org.shredzone.acme4j.util.KeyPairUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.SimpleResolver;
+import org.xbill.DNS.Type;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Service for managing Cerificates and calls to the ACME cert provider
+ *
+ * TODO: Update TOS
+ * TODO: Rotate ACME user private key
+ * TODO: Support Venafi ACME Impl
+ */
+@SuppressFBWarnings(value = {
+        "DM_DEFAULT_ENCODING",
+        "REC_CATCH_EXCEPTION"
+})
+public class CertificateService {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    // File name of the PKCS #1 private key pem for the ACME registration, this represents a "User"
+    public static final String USER_KEY_FILE = "acme-user-private-key-pkcs1.pem";
+
+    // File name of the PKCS #1 private key pem for the Cerberus domain
+    public static final String DOMAIN_PKCS1_KEY_FILE = "domain-private-key-pkcs1.pem";
+
+    // File name of the PKCS #8 private key pem for the Cerberus domain
+    public static final String DOMAIN_PKCS8_KEY_FILE = "domain-private-key-pkcs8.pem";
+
+    // File name of pub key pem
+    public static final String PUB_KEY_FILE = "domain-public-key.pem";
+
+    // File name of the CSR
+    public static final String DOMAIN_CSR_FILE = "domain.csr";
+
+    // File name of the signed certificate
+    public static final String DOMAIN_FULL_CERT_WITH_CHAIN_CRT_FILE = "domain-full-cert-with-chain.crt";
+
+    // File name of the signed certificate
+    public static final String DOMAIN_CERT_FILE = "domain-cert.crt";
+
+    // File name of the ca chain
+    public static final String CERT_CHAIN_FILE = "chain.crt";
+
+    // RSA key size of generated key pairs
+    private static final int KEY_SIZE = 2048;
+
+    protected static final String CHALLENGE_ENTRY_TEMPLATE = "_acme-challenge.%s";
+
+    private final ConsoleService console;
+    private final AmazonRoute53 route53;
+
+    @Inject
+    public CertificateService(ConsoleService console,
+                              AmazonRoute53 route53) {
+
+        this.console = console;
+        this.route53 = route53;
+    }
+
+    /**
+     * Finds your {@link Registration} at the ACME server. It will be found by your user's
+     * public key. If your key is not known to the server yet, a new registration will be
+     * created.
+     * <p>
+     * This is a simple way of finding your {@link Registration}. A better way is to get
+     * the URI of your new registration with {@link Registration#getLocation()} and store
+     * it somewhere. If you need to get access to your account later, reconnect to it via
+     * {@link Registration#bind(Session, URI)} by using the stored location.
+     *
+     * @param session
+     *            {@link Session} to bind with
+     * @return {@link Registration} connected to your account
+     */
+    protected Registration findOrRegisterAccount(Session session, String contactEmail) throws AcmeException, IOException {
+        Registration reg;
+        try {
+            // Try to create a new Registration.
+            reg = new RegistrationBuilder().addContact("mailto:" + contactEmail).create(session);
+            log.info("Registered a new user, URI: " + reg.getLocation());
+
+            // This is a new account. Let the user accept the Terms of Service.
+            // We won't be able to authorize domains until the ToS is accepted.
+            URI agreement = reg.getAgreement();
+
+            if (! (agreement == null)) {
+                acceptAgreement(reg, agreement);
+            }
+        } catch (AcmeConflictException ex) {
+            // The Key Pair is already registered. getLocation() contains the
+            // URL of the existing registration's location. Bind it to the session.
+            reg = Registration.bind(session, ex.getLocation());
+            log.info("Account already exist, URI: {}, no need to create new account", reg.getLocation());
+        }
+        return reg;
+    }
+
+    /**
+     * Prompts a user to read and accept or deny a ACME providers TOS
+     *
+     * @param reg The registration object
+     * @param agreement The link to the TOS
+     */
+    protected void acceptAgreement(Registration reg, URI agreement) {
+        try {
+            log.info("Please download and review the Terms of Service: " + agreement);
+            String userResponse = console.readLine("Type \"I Accept\" to accept the Terms of Service, anything else will exit: ");
+            if (! StringUtils.equalsIgnoreCase("I Accept", userResponse)) {
+                throw new RuntimeException("User did not accept the Terms of Service");
+            }
+            reg.modify().setAgreement(agreement).commit();
+            log.info("Updated user's ToS");
+        } catch (AcmeException | IOException e) {
+            throw new RuntimeException("Failed to accept ACME TOS", e);
+        }
+    }
+
+    /**
+     * Creates a Txt record in Route53
+     *
+     * @param name The record name
+     * @param digest The value for the txt record
+     * @param hostedZoneId The hosted zone id to create the record in
+     */
+    protected void generateChallengeTxtEntry(String name, String digest, String hostedZoneId) {
+        ResourceRecordSet recordSet = new ResourceRecordSet()
+                .withName(name)
+                .withType(RRType.TXT)
+                .withTTL(10L)
+                .withResourceRecords(
+                        new ResourceRecord(String.format("\"%s\"", digest))
+                );
+
+        createOrUpdateRecordSets(recordSet, hostedZoneId);
+    }
+
+    protected void createOrUpdateRecordSets(ResourceRecordSet recordSet, String hostedZoneId) {
+        ChangeBatch changeBatch = new ChangeBatch().withChanges(
+                new Change()
+                        .withAction(ChangeAction.UPSERT)
+                        .withResourceRecordSet(recordSet)
+        );
+
+        route53.changeResourceRecordSets(new ChangeResourceRecordSetsRequest()
+                .withChangeBatch(changeBatch)
+                .withHostedZoneId(hostedZoneId));
+    }
+
+    /**
+     * Uses DNS to get a txt record
+     *
+     * @param cname the txt record to loop up
+     * @return Value of record if present
+     */
+    protected Optional<String> getTxtRecordValue(String cname) {
+        try {
+            Lookup lookup = new Lookup(cname, Type.TXT);
+            lookup.setResolver(new SimpleResolver());
+            lookup.setCache(null);
+            Record[] records = lookup.run();
+            return Optional.of(records[0].rdataToString());
+        } catch (Exception e) {
+            log.error("Failed to look up txt record for {} reason: {}", cname, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Loads a key pair from specified file. If the file does not exist,
+     * a new key pair is generated and saved.
+     *
+     * @return {@link KeyPair}.
+     */
+    protected KeyPair loadOrCreateKeyPair(File file) throws IOException {
+        if (file.exists()) {
+            try (FileReader fr = new FileReader(file)) {
+                return KeyPairUtils.readKeyPair(fr);
+            }
+        } else {
+            KeyPair domainKeyPair = KeyPairUtils.createKeyPair(KEY_SIZE);
+            try (FileWriter fw = new FileWriter(file)) {
+                KeyPairUtils.writeKeyPair(domainKeyPair, fw);
+            }
+            return domainKeyPair;
+        }
+    }
+
+
+    /**
+     * Generates the certs needed for a Cerberus Environment
+     *
+     * @param certDir The folder to store the generated files
+     * @param commonName The primary CNAME for the cert
+     * @param subjectAlternativeNames Additional CNAMEs for the cert
+     * @param hostedZoneId The hosted zone id that can be used to create txt records for the ACME ownership challenges
+     */
+    public void generateCerts(File certDir,
+                              String acmeServerUrl,
+                              String commonName,
+                              Set<String> subjectAlternativeNames,
+                              String hostedZoneId,
+                              String contactEmail) {
+
+        try {
+            List<String> names = new LinkedList<>();
+            names.add(commonName); // the first entry counts as the common name
+            names.addAll(subjectAlternativeNames);
+
+            KeyPair userKeyPair = loadOrCreateKeyPair(new File(certDir.getAbsolutePath() + File.separator + USER_KEY_FILE));
+
+            Session session = new Session(acmeServerUrl, userKeyPair);
+            Registration registration = findOrRegisterAccount(session, contactEmail);
+
+            for (String name : names) {
+                Authorization authorization = registration.authorizeDomain(name);
+                getChallenges(authorization).forEach(challenge -> doChallenge(challenge, name, hostedZoneId));
+            }
+
+            KeyPair domainKeyPair = loadOrCreateKeyPair(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_PKCS1_KEY_FILE));
+            createPKCS8PrivateKeyPemFileFromKeyPair(domainKeyPair, certDir);
+            createPKCS1PublicKeyPem(domainKeyPair, certDir);
+            CSRBuilder csrb = new CSRBuilder();
+            csrb.addDomains(names);
+            csrb.sign(domainKeyPair);
+
+            try (Writer csrWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CSR_FILE))) {
+                csrb.write(csrWriter);
+            }
+
+            // Now request a signed certificate.
+            Certificate certificate = registration.requestCertificate(csrb.getEncoded());
+
+            log.info("Success! The certificate has been generated!");
+            log.info("Certificate URI: " + certificate.getLocation());
+
+            // Download the leaf certificate and certificate chain.
+            X509Certificate cert = certificate.download();
+            X509Certificate[] chain = certificate.downloadChain();
+
+            // Write a combined file containing the certificate and chain.
+            try (FileWriter fullCertWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_FULL_CERT_WITH_CHAIN_CRT_FILE))) {
+                CertificateUtils.writeX509CertificateChain(fullCertWriter, cert, chain);
+            }
+            // write just the cert
+            try (FileWriter certWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CERT_FILE))) {
+                CertificateUtils.writeX509Certificate(cert, certWriter);
+            }
+            // write just the chain
+            try (FileWriter chainWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + CERT_CHAIN_FILE))) {
+                CertificateUtils.writeX509CertificateChain(chainWriter, null, chain);
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to generate certs", e);
+        }
+    }
+
+    /**
+     * Takes a challenge and performs it
+     *
+     * @param challenge The challenge
+     * @param domainName The domain that is being verified
+     * @param hostedZone The hosted zone id if applicable
+     */
+    protected void doChallenge(Challenge challenge, String domainName, String hostedZone) {
+        switch (challenge.getType()) {
+            case Dns01Challenge.TYPE:
+                doDns01Challenge((Dns01Challenge) challenge, domainName, hostedZone);
+                break;
+            default:
+                throw new RuntimeException("Unsupported challenge type: " + challenge.getType());
+        }
+    }
+
+    /**
+     * Attempts to get an acceptable challenge from the ACME provider.
+     *
+     * This CLI currently only supports DNS-01 Challenges
+     *
+     * @param authorization The authorization object from the ACME provider
+     * @return a Collection of challenges to complete.
+     */
+    protected Collection<Challenge> getChallenges(Authorization authorization) {
+        List<String[]> desiredChallengeCombos = ImmutableList.of(
+                new String[]{Dns01Challenge.TYPE}
+        );
+
+        for (String[] desiredChallengeCombo : desiredChallengeCombos) {
+            Collection<Challenge> challenges = authorization.findCombination(desiredChallengeCombo);
+            if (! challenges.isEmpty()) {
+                return challenges;
+            }
+        }
+
+        String apiSupportedChallenges = new Gson().toJson(authorization.getCombinations());
+        String cliSupportedMethods = new Gson().toJson(desiredChallengeCombos);
+        throw new RuntimeException("Failed to find a supportable combination of domain verification challenges. " +
+                "Supported challenge combos by the API: " + apiSupportedChallenges +
+                ", challenge combos supported by the CLI: " + cliSupportedMethods);
+    }
+
+    /**
+     * Performs the ACME DNS 01 Challenge by creating txt records in Route 53
+     *
+     * @param challenge The ACME challenge info with digest
+     * @param domainName The domain name that is being verified
+     * @param hostedZoneId The hosted zone id that has permissions to create dns records for the domain name
+     */
+    protected void doDns01Challenge(Dns01Challenge challenge, String domainName, String hostedZoneId) {
+        String digest = challenge.getDigest();
+        try {
+            String cname = String.format(CHALLENGE_ENTRY_TEMPLATE, domainName);
+            generateChallengeTxtEntry(cname, digest, hostedZoneId);
+            Optional<String> recordValue;
+            do {
+                log.info("Waiting for name: '{}' to have txt record digest value: '{}' before triggering challenge", cname, digest);
+                Thread.sleep(TimeUnit.SECONDS.toMillis(60));
+                recordValue = getTxtRecordValue(cname);
+            } while (! recordValue.isPresent() || ! recordValue.get().equals(String.format("\"%s\"", digest)));
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Failed to complete DNS 01 challenge", e);
+        }
+
+        triggerChallenge(challenge);
+    }
+
+    /**
+     * Triggers the ACME challenge polling for its status to be complete
+     *
+     * @param challenge The challenge that is ready to be triggered
+     */
+    protected void triggerChallenge(Challenge challenge) {
+        try {
+            challenge.trigger();
+
+            // TODO better polling is possible, this can cause infinite loops
+            while (challenge.getStatus() != Status.VALID) {
+                log.info("Waiting for challenge to complete");
+                Thread.sleep(3000);
+                challenge.update();
+            }
+            log.info("challenge accepted");
+        } catch (AcmeException | InterruptedException e) {
+            log.error("failed to trigger and wait for challenge to be accepted", e);
+        }
+    }
+
+    protected void createPKCS1PublicKeyPem(KeyPair keyPair, File certDir) {
+        try {
+            FileWriter pubKeyWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + PUB_KEY_FILE));
+            try (JcaPEMWriter jw = new JcaPEMWriter(pubKeyWriter)) {
+                jw.writeObject(keyPair.getPublic());
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create pub key pem", e);
+        }
+    }
+
+    /**
+     * Netty, which is what CMS is using requires the private key to be in PKCS8 format
+     * http://netty.io/wiki/sslcontextbuilder-and-private-key.html
+     */
+    protected void createPKCS8PrivateKeyPemFileFromKeyPair(KeyPair keyPair, File certDir) {
+        try {
+            JcaPKCS8Generator pkcs8Generator = new JcaPKCS8Generator(keyPair.getPrivate(), null);
+            PemObject pemObject = pkcs8Generator.generate();
+            FileWriter fileWriter = new FileWriter(new File(certDir.getAbsolutePath()
+                    + File.separator + DOMAIN_PKCS8_KEY_FILE));
+            try (JcaPEMWriter pemWriter = new JcaPEMWriter(fileWriter)) {
+                pemWriter.writeObject(pemObject);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create PKCS8 private key pem", e);
+        }
+    }
+}

--- a/src/main/java/com/nike/cerberus/service/CertificateService.java
+++ b/src/main/java/com/nike/cerberus/service/CertificateService.java
@@ -92,19 +92,19 @@ public class CertificateService {
     public static final String DOMAIN_PKCS8_KEY_FILE = "domain-private-key-pkcs8.pem";
 
     // File name of pub key pem
-    public static final String PUB_KEY_FILE = "domain-public-key.pem";
+    public static final String DOMAIN_PUBLIC_KEY_FILE = "domain-public-key.pem";
 
-    // File name of the CSR
+    // File name of the certificate signing request
     public static final String DOMAIN_CSR_FILE = "domain.csr";
 
-    // File name of the signed certificate
+    // File name of the signed certificate with chain
     public static final String DOMAIN_FULL_CERT_WITH_CHAIN_CRT_FILE = "domain-full-cert-with-chain.crt";
 
     // File name of the signed certificate
     public static final String DOMAIN_CERT_FILE = "domain-cert.crt";
 
-    // File name of the ca chain
-    public static final String CERT_CHAIN_FILE = "chain.crt";
+    // File name of the certificate chain
+    public static final String DOMAIN_CERT_CHAIN_FILE = "chain.crt";
 
     // RSA key size of generated key pairs
     private static final int KEY_SIZE = 2048;
@@ -310,7 +310,7 @@ public class CertificateService {
                 CertificateUtils.writeX509Certificate(cert, certWriter);
             }
             // write just the chain
-            try (FileWriter chainWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + CERT_CHAIN_FILE))) {
+            try (FileWriter chainWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_CERT_CHAIN_FILE))) {
                 CertificateUtils.writeX509CertificateChain(chainWriter, null, chain);
             }
 
@@ -411,7 +411,7 @@ public class CertificateService {
 
     protected void createPKCS1PublicKeyPem(KeyPair keyPair, File certDir) {
         try {
-            FileWriter pubKeyWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + PUB_KEY_FILE));
+            FileWriter pubKeyWriter = new FileWriter(new File(certDir.getAbsolutePath() + File.separator + DOMAIN_PUBLIC_KEY_FILE));
             try (JcaPEMWriter jw = new JcaPEMWriter(pubKeyWriter)) {
                 jw.writeObject(keyPair.getPublic());
             }

--- a/src/main/java/com/nike/cerberus/service/ConsoleService.java
+++ b/src/main/java/com/nike/cerberus/service/ConsoleService.java
@@ -17,6 +17,7 @@
 package com.nike.cerberus.service;
 
 import com.google.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -44,5 +45,46 @@ public class ConsoleService {
             return System.console().readPassword(format, args);
         }
         return readLine(format, args).toCharArray();
+    }
+
+    public void askUserToProceed(String additionalMessage, DefaultAction defaultAction) {
+        String userInput;
+        try {
+            StringBuilder sb = new StringBuilder();
+            if (StringUtils.isNotBlank(additionalMessage)) {
+                sb.append(additionalMessage).append('\n');
+            }
+            sb.append("Would you like to proceed? ")
+                    .append(defaultAction.isYesDefault() ? "(Y/n)" : "(y/N)")
+                    .append(": ");
+            userInput = readLine(sb.toString());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to ask user to proceed", e);
+        }
+
+        if (StringUtils.isBlank(userInput) && defaultAction.isYesDefault()) {
+            return;
+        }
+
+        if (StringUtils.isNotBlank(userInput) && (userInput.equalsIgnoreCase("y") || userInput.equalsIgnoreCase("yes"))) {
+            return;
+        }
+
+        throw new RuntimeException("User declined to proceed");
+    }
+
+    public enum DefaultAction {
+        YES(true),
+        NO(false);
+
+        private boolean yesIsDefault;
+
+        protected boolean isYesDefault() {
+            return yesIsDefault;
+        }
+
+        DefaultAction(boolean yesIsDefault) {
+            this.yesIsDefault = yesIsDefault;
+        }
     }
 }


### PR DESCRIPTION
Adding generate cert command that has an Integration Test that is passing with LetsEncrypt ACME api.

This command just creates the files locally and relies on the existing upload cert command to upload to S3 / IAM. Plan is to possibly stream line this once @sdford's changes get merged and I do the rotate command.

Take a look at the Generate Certs Operation Integration Test for my testing methodology.