### PR TITLE
Feature/composite command pattern

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -38,7 +38,7 @@ allprojects {
 
         compile 'com.nike:vault-client:1.4.1'
         compile 'com.squareup.okhttp3:okhttp:3.3.1'
-        compile 'com.beust:jcommander:1.55'
+        compile 'com.beust:jcommander:1.72'
 
         compile 'com.fasterxml.jackson.core:jackson-core:2.7.+'
         compile 'com.fasterxml.jackson.core:jackson-databind:2.7.+'

--- a/src/main/java/com/nike/cerberus/cli/CerberusRunner.java
+++ b/src/main/java/com/nike/cerberus/cli/CerberusRunner.java
@@ -31,6 +31,7 @@ import com.nike.cerberus.command.cms.CreateCmsClusterCommand;
 import com.nike.cerberus.command.cms.CreateCmsCmkCommand;
 import com.nike.cerberus.command.cms.CreateCmsConfigCommand;
 import com.nike.cerberus.command.cms.UpdateCmsConfigCommand;
+import com.nike.cerberus.command.composite.PrintAllStackInformationCommand;
 import com.nike.cerberus.command.core.CreateCerberusBackupCommand;
 import com.nike.cerberus.command.core.GenerateCertsCommand;
 import com.nike.cerberus.command.core.CreateDatabaseCommand;
@@ -99,8 +100,7 @@ public class CerberusRunner {
             } else if (cerberusCommand.isHelp() || commandName == null) {
                 cerberusHelp.print();
             } else {
-                Injector injector = Guice.createInjector(new CerberusModule(cerberusCommand.getProxyDelegate(),
-                        cerberusCommand.getEnvironment(), cerberusCommand.getRegion()), new PropsModule());
+                Injector injector = Guice.createInjector(new CerberusModule(cerberusCommand), new PropsModule());
 
                 // fail early if there is any problem in local environment
                 LocalEnvironmentValidator validator = injector.getInstance(LocalEnvironmentValidator.class);
@@ -170,6 +170,7 @@ public class CerberusRunner {
         registerCommand(new CreateCmsCmkCommand());
         registerCommand(new UpdateStackCommand());
         registerCommand(new PrintStackInfoCommand());
+        registerCommand(new PrintAllStackInformationCommand());
         registerCommand(new WhitelistCidrForVpcAccessCommand());
         registerCommand(new RestoreCerberusBackupCommand());
         registerCommand(new ViewConfigCommand());

--- a/src/main/java/com/nike/cerberus/cli/EnvironmentConfigToArgsMapper.java
+++ b/src/main/java/com/nike/cerberus/cli/EnvironmentConfigToArgsMapper.java
@@ -107,9 +107,7 @@ public class EnvironmentConfigToArgsMapper {
             case CreateWafCommand.COMMAND_NAME:
                 return getCreateWafCommandArgs(environmentConfig);
             default:
-                List<String> passedArgsList = new LinkedList<>();
-                passedArgsList.addAll(Arrays.asList(passedArgs));
-                return passedArgsList;
+                return new LinkedList<>();
         }
     }
 

--- a/src/main/java/com/nike/cerberus/cli/EnvironmentConfigToArgsMapper.java
+++ b/src/main/java/com/nike/cerberus/cli/EnvironmentConfigToArgsMapper.java
@@ -78,7 +78,7 @@ public class EnvironmentConfigToArgsMapper {
         return args.toArray(new String[args.size()]);
     }
 
-    private static List<String> getArgsForCommand(EnvironmentConfig environmentConfig, String commandName, String[] passedArgs) {
+    public static List<String> getArgsForCommand(EnvironmentConfig environmentConfig, String commandName, String[] passedArgs) {
         switch (commandName) {
             case CreateBaseCommand.COMMAND_NAME:
                 return getCreateBaseCommandArgs(environmentConfig);
@@ -107,7 +107,9 @@ public class EnvironmentConfigToArgsMapper {
             case CreateWafCommand.COMMAND_NAME:
                 return getCreateWafCommandArgs(environmentConfig);
             default:
-                return new LinkedList<>();
+                List<String> passedArgsList = new LinkedList<>();
+                passedArgsList.addAll(Arrays.asList(passedArgs));
+                return passedArgsList;
         }
     }
 

--- a/src/main/java/com/nike/cerberus/command/composite/PrintAllStackInformationCommand.java
+++ b/src/main/java/com/nike/cerberus/command/composite/PrintAllStackInformationCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.command.composite;
+
+import com.beust.jcommander.Parameters;
+import com.nike.cerberus.command.Command;
+import com.nike.cerberus.operation.Operation;
+import com.nike.cerberus.operation.composite.PrintAllStackInformationOperation;
+
+import static com.nike.cerberus.command.composite.PrintAllStackInformationCommand.COMMAND_NAME;
+
+/**
+ * Prints information for all the stacks
+ */
+@Parameters(
+        commandNames = COMMAND_NAME,
+        commandDescription = "Iterates through all known stacks for a cerberus environment and prints the stack info"
+)
+public class PrintAllStackInformationCommand implements Command {
+
+    public static final String COMMAND_NAME = "print-stack-info-for-all-stacks";
+
+    @Override
+    public String getCommandName() {
+        return COMMAND_NAME;
+    }
+
+    @Override
+    public Class<? extends Operation<?>> getOperationClass() {
+        return PrintAllStackInformationOperation.class;
+    }
+}

--- a/src/main/java/com/nike/cerberus/command/core/PrintStackInfoCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/PrintStackInfoCommand.java
@@ -33,7 +33,9 @@ public class PrintStackInfoCommand implements Command {
 
     public static final String COMMAND_NAME = "print-stack-info";
 
-    @Parameter(names = {"--stack-name"}, required = true, description = "The stack name to print information about.")
+    public static final String STACK_NAME_LONG_ARG = "--stack-name";
+
+    @Parameter(names = {STACK_NAME_LONG_ARG}, required = true, description = "The stack name to print information about.")
     private StackName stackName;
 
     public StackName getStackName() {

--- a/src/main/java/com/nike/cerberus/module/CerberusModule.java
+++ b/src/main/java/com/nike/cerberus/module/CerberusModule.java
@@ -56,9 +56,12 @@ import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.MustacheFactory;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.util.Providers;
 import com.nike.cerberus.ConfigConstants;
+import com.nike.cerberus.command.CerberusCommand;
 import com.nike.cerberus.command.ProxyDelegate;
 import com.nike.cerberus.domain.EnvironmentMetadata;
+import com.nike.cerberus.domain.input.EnvironmentConfig;
 import com.nike.cerberus.util.TokenSupplier;
 import com.nike.cerberus.util.UuidSupplier;
 import org.apache.commons.lang3.StringUtils;
@@ -94,10 +97,13 @@ public class CerberusModule extends AbstractModule {
 
     private final String regionName;
 
-    public CerberusModule(ProxyDelegate proxyDelegate, String environmentName, String regionName) {
-        this.proxyDelegate = proxyDelegate;
-        this.environmentName = environmentName;
-        this.regionName = regionName;
+    private final EnvironmentConfig environmentConfig;
+
+    public CerberusModule(CerberusCommand cerberusCommand) {
+        proxyDelegate = cerberusCommand.getProxyDelegate();
+        environmentName = cerberusCommand.getEnvironment();
+        regionName = cerberusCommand.getRegion();
+        environmentConfig = cerberusCommand.getEnvironmentConfig();
     }
 
     /**
@@ -105,6 +111,7 @@ public class CerberusModule extends AbstractModule {
      */
     @Override
     protected void configure() {
+        bind(EnvironmentConfig.class).toProvider(Providers.of(environmentConfig));
         final Region region = Region.getRegion(Regions.fromName(regionName));
         bind(AmazonEC2.class).toInstance(createAmazonClientInstance(AmazonEC2Client.class, region));
         bind(AmazonCloudFormation.class).toInstance(createAmazonClientInstance(AmazonCloudFormationClient.class, region));

--- a/src/main/java/com/nike/cerberus/module/CerberusModule.java
+++ b/src/main/java/com/nike/cerberus/module/CerberusModule.java
@@ -38,6 +38,8 @@ import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClient;
 import com.amazonaws.services.lambda.AWSLambda;
 import com.amazonaws.services.lambda.AWSLambdaClient;
+import com.amazonaws.services.route53.AmazonRoute53;
+import com.amazonaws.services.route53.AmazonRoute53Client;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.Bucket;
@@ -113,6 +115,7 @@ public class CerberusModule extends AbstractModule {
         bind(AWSSecurityTokenService.class).toInstance(createAmazonClientInstance(AWSSecurityTokenServiceClient.class, region));
         bind(AWSLambda.class).toInstance(createAmazonClientInstance(AWSLambdaClient.class, region));
         bind(AmazonSNS.class).toInstance(createAmazonClientInstance(AmazonSNSClient.class, region));
+        bind(AmazonRoute53.class).toInstance(createAmazonClientInstance(AmazonRoute53Client.class, region));
     }
 
     /**

--- a/src/main/java/com/nike/cerberus/operation/composite/ChainableCommand.java
+++ b/src/main/java/com/nike/cerberus/operation/composite/ChainableCommand.java
@@ -18,10 +18,20 @@ package com.nike.cerberus.operation.composite;
 
 import com.nike.cerberus.command.Command;
 import com.nike.cerberus.operation.Operation;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.LinkedList;
 import java.util.List;
 
+@SuppressFBWarnings(
+        value = "EI_EXPOSE_REP",
+        justification = "We don't care"
+)
+/**
+ * Wrapper object to represent a chainable command.
+ *
+ * @See CompositeOperation
+ */
 public class ChainableCommand {
 
     private Command command;

--- a/src/main/java/com/nike/cerberus/operation/composite/ChainableCommand.java
+++ b/src/main/java/com/nike/cerberus/operation/composite/ChainableCommand.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.operation.composite;
+
+import com.nike.cerberus.command.Command;
+import com.nike.cerberus.operation.Operation;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ChainableCommand {
+
+    private Command command;
+    private Operation operation;
+    private String[] additionalArgs;
+
+    public Command getCommand() {
+        return command;
+    }
+
+    public String[] getAdditionalArgs() {
+        return additionalArgs;
+    }
+
+    public Operation getOperation() {
+        return operation;
+    }
+
+    public void setOperation(Operation operation) {
+        this.operation = operation;
+    }
+
+    public static final class Builder {
+        private Command command;
+        private List<String> additionalArgs = new LinkedList<>();
+
+        private Builder() {
+        }
+
+        public static Builder create() {
+            return new Builder();
+        }
+
+        public Builder withCommand(Command command) {
+            this.command = command;
+            return this;
+        }
+
+        public Builder withAdditionalArg(String additionalArg) {
+            additionalArgs.add(additionalArg);
+            return this;
+        }
+
+        public ChainableCommand build() {
+            ChainableCommand chainableCommand = new ChainableCommand();
+            chainableCommand.command = this.command;
+            chainableCommand.additionalArgs = this.additionalArgs.toArray(new String[additionalArgs.size()]);
+            return chainableCommand;
+        }
+    }
+}

--- a/src/main/java/com/nike/cerberus/operation/composite/CompositeOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/composite/CompositeOperation.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.operation.composite;
+
+import com.beust.jcommander.JCommander;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.nike.cerberus.cli.EnvironmentConfigToArgsMapper;
+import com.nike.cerberus.command.Command;
+import com.nike.cerberus.domain.input.EnvironmentConfig;
+import com.nike.cerberus.operation.Operation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.LinkedList;
+import java.util.List;
+
+public abstract class CompositeOperation<T extends Command> implements Operation<T> {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private Injector injector;
+
+    private EnvironmentConfig environmentConfig;
+
+    private List<ChainableCommand> runnableChainedCommands = new LinkedList<>();
+
+    @Inject
+    public void setInjector(Injector injector) {
+        this.injector = injector;
+    }
+
+    @Inject
+    public void setEnvironmentConfig(@Nullable EnvironmentConfig environmentConfig) {
+        this.environmentConfig = environmentConfig;
+    }
+
+    private Operation getOperationInstance(Command command) {
+        return injector.getInstance(command.getOperationClass());
+    }
+
+    @SuppressWarnings("unchecked")
+    public void run(T compositeCommand) {
+        runnableChainedCommands.forEach(chainableCommand -> {
+            Command chainedCommand = chainableCommand.getCommand();
+            Operation chainedOperation = chainableCommand.getOperation();
+            log.info("Attempting to run command: {}", chainedCommand.getCommandName());
+            try {
+                chainedOperation.run(chainedCommand);
+            } catch (Throwable e) {
+                throw new RuntimeException("Failed to execute chained command: " + chainedCommand.getCommandName(), e);
+            }
+            log.info("Finished command: {}", chainedCommand.getCommandName());
+
+        });
+    }
+
+    public boolean isRunnable(T command) {
+        if (getIsEnvironmentConfigRequired() && environmentConfig == null) {
+            throw new RuntimeException(String.format("The %s command requires that -f or --file must be supplied as a global option with " +
+                    "a path to a valid environment yaml", command.getCommandName()));
+        }
+
+        for (ChainableCommand chainableCommand : getCompositeCommandChain()) {
+            Command chainedCommand = chainableCommand.getCommand();
+            String[] additionalArgs = chainableCommand.getAdditionalArgs();
+
+            // Parse the yaml and additional args to get args to pass to jcommander
+            List<String> argsList = EnvironmentConfigToArgsMapper.getArgsForCommand(
+                    environmentConfig, chainedCommand.getCommandName(), additionalArgs);
+
+            // convert args list to args array
+            String[] args = argsList.toArray(new String[argsList.size()]);
+
+            // Bind args to object
+            JCommander.newBuilder().addObject(chainedCommand).build().parse(args);
+
+            // Get the instance of the operation from guice
+            Operation operation = getOperationInstance(chainedCommand);
+
+            //noinspection unchecked
+            if (! operation.isRunnable(chainedCommand)) {
+                return false;
+            }
+            log.debug("Command: {} with Args: {} is runnable, adding to runnable list", chainedCommand.getCommandName(), args);
+            chainableCommand.setOperation(operation);
+            runnableChainedCommands.add(chainableCommand);
+        }
+        return true;
+    }
+
+    protected abstract List<ChainableCommand> getCompositeCommandChain();
+
+    public boolean getIsEnvironmentConfigRequired() {
+        return true;
+    }
+}

--- a/src/main/java/com/nike/cerberus/operation/composite/PrintAllStackInformationOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/composite/PrintAllStackInformationOperation.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.operation.composite;
+
+import com.nike.cerberus.command.composite.PrintAllStackInformationCommand;
+import com.nike.cerberus.command.core.PrintStackInfoCommand;
+import com.nike.cerberus.domain.environment.StackName;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Composite Command for printing stack info for entire Cerberus Environment
+ */
+public class PrintAllStackInformationOperation extends CompositeOperation<PrintAllStackInformationCommand> {
+
+    @Override
+    protected List<ChainableCommand> getCompositeCommandChain() {
+        List<ChainableCommand> commandList = new LinkedList<>();
+
+        for (StackName stackName : StackName.values()) {
+            commandList.add(
+                    ChainableCommand.Builder.create()
+                            .withCommand(new PrintStackInfoCommand())
+                            .withAdditionalArg(PrintStackInfoCommand.STACK_NAME_LONG_ARG)
+                            .withAdditionalArg(stackName.toString())
+                            .build()
+            );
+        }
+
+        return commandList;
+    }
+
+    @Override
+    public boolean getIsEnvironmentConfigRequired() {
+        return false;
+    }
+
+}

--- a/src/test/java/com/nike/cerberus/cli/EnvironmentConfigToArgsMapperTest.java
+++ b/src/test/java/com/nike/cerberus/cli/EnvironmentConfigToArgsMapperTest.java
@@ -62,7 +62,7 @@ public class EnvironmentConfigToArgsMapperTest {
 
         String[] actual = EnvironmentConfigToArgsMapper.getArgs(environmentConfig, userInput);
 
-        assertArgsAreEqual(expected, actual,commandName);
+        assertArgsAreEqual(expected, actual, commandName);
     }
 
     @Test
@@ -78,7 +78,7 @@ public class EnvironmentConfigToArgsMapperTest {
 
         String[] actual = EnvironmentConfigToArgsMapper.getArgs(environmentConfig, userInput);
 
-        assertArgsAreEqual(expected, actual,commandName);
+        assertArgsAreEqual(expected, actual, commandName);
     }
 
 
@@ -99,7 +99,7 @@ public class EnvironmentConfigToArgsMapperTest {
 
         String[] actual = EnvironmentConfigToArgsMapper.getArgs(environmentConfig, userInput);
 
-        assertArgsAreEqual(expected, actual,commandName);
+        assertArgsAreEqual(expected, actual, commandName);
     }
 
     @Test


### PR DESCRIPTION
- Add abstract composite command and example command to allow the creation of complex command chains
- Add example composite command `print-stack-info-for-all-stacks` that prints out all known stack information for all the stacks that comprise a Cerberus environment.