### PR TITLE
tokenize the environment name where needed

### DIFF
--- a/src/main/java/com/nike/cerberus/domain/environment/Stack.java
+++ b/src/main/java/com/nike/cerberus/domain/environment/Stack.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Nike, Inc.
+ * Copyright (c) 2017 Nike, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,8 @@ public class Stack {
      * @return The generated CloudFormation stack name
      */
     public String getFullName(String environmentName) {
-        return String.format("%s-cerberus-%s", environmentName, name);
+        String tokenizedEnvName = StringUtils.replaceAll(environmentName, "_", "-");
+        return String.format("%s-cerberus-%s", tokenizedEnvName, name);
     }
 
     public static Stack fromName(final String name) {

--- a/src/main/java/com/nike/cerberus/module/CerberusModule.java
+++ b/src/main/java/com/nike/cerberus/module/CerberusModule.java
@@ -217,10 +217,11 @@ public class CerberusModule extends AbstractModule {
 
         String envBucket = null;
         for (final Bucket bucket : buckets) {
+            String bucketName = bucket.getName();
             if (StringUtils.contains(bucket.getName(), ConfigConstants.CONFIG_BUCKET_KEY)) {
-                String[] parts = bucket.getName().split("-");
-                if (StringUtils.equalsIgnoreCase(environmentName, parts[0])) {
-                    envBucket = bucket.getName();
+                String tokenizedEnvName = StringUtils.replaceAll(environmentName, "_", "-");
+                if (StringUtils.startsWith(bucketName, tokenizedEnvName)) {
+                    envBucket = bucketName;
                     break;
                 }
             }


### PR DESCRIPTION
tokenize the environment name in order to support _ chars in env name, which the cli allows when creating environments

I noticed when I made an env called `dev_hl` things broke down.