### PR TITLE
Make the operation validate file existance at runtime rather than whe…

### DIFF
--- a/src/main/java/com/nike/cerberus/command/validator/UploadCertFilesPathValidator.java
+++ b/src/main/java/com/nike/cerberus/command/validator/UploadCertFilesPathValidator.java
@@ -18,17 +18,9 @@ package com.nike.cerberus.command.validator;
 
 import com.beust.jcommander.IValueValidator;
 import com.beust.jcommander.ParameterException;
-import com.beust.jcommander.internal.Sets;
-import org.apache.commons.io.filefilter.RegexFileFilter;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Set;
-import java.util.StringJoiner;
-
-import static com.nike.cerberus.operation.core.UploadCertFilesOperation.EXPECTED_FILE_NAMES;
 
 /**
  * Validates that the specified directory contains all the correct files for cert upload.
@@ -43,7 +35,6 @@ public class UploadCertFilesPathValidator implements IValueValidator<Path> {
         }
 
         final File certDirectory = value.toFile();
-        final Set<String> filenames = Sets.newHashSet();
 
         if (!certDirectory.canRead()) {
             throw new ParameterException("Specified path is not readable.");
@@ -51,17 +42,6 @@ public class UploadCertFilesPathValidator implements IValueValidator<Path> {
 
         if (!certDirectory.isDirectory()) {
             throw new ParameterException("Specified path is not a directory.");
-        }
-
-
-        final FilenameFilter filter = new RegexFileFilter("^.*\\.(pem|crt)$");
-        final File[] files = certDirectory.listFiles(filter);
-        Arrays.stream(files).forEach(file -> filenames.add(file.getName()));
-
-        if (!filenames.containsAll(EXPECTED_FILE_NAMES)) {
-            final StringJoiner sj = new StringJoiner(", ", "[", "]");
-            EXPECTED_FILE_NAMES.stream().forEach(sj::add);
-            throw new ParameterException("Not all expected files are present! Expected: " + sj.toString());
         }
     }
 }


### PR DESCRIPTION
Make the upload cert operation validate at runtime so the command can be used in a composite command.

Currently it validates file existence when you bind the args to the command through jcommander causing a runtime exception before the generate certs command can run.