### PR TITLE
Feature/create cms cmk validate in isRunable rather than run

### DIFF
--- a/src/main/java/com/nike/cerberus/operation/cms/CreateCmsCmkOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/cms/CreateCmsCmkOperation.java
@@ -69,10 +69,6 @@ public class CreateCmsCmkOperation implements Operation<CreateCmsCmkCommand> {
         logger.info("Retrieving configuration data from the configuration bucket.");
         final Properties cmsConfigProperties = configStore.getAllExistingCmsEnvProperties();
 
-        // additional argument validation
-        validateRegionsArg(command);
-        validateRotateArg(command, cmsConfigProperties);
-
         // create the CMKs
         List<String> cmkArns = createCmks(command, cmsConfigProperties);
 
@@ -90,6 +86,16 @@ public class CreateCmsCmkOperation implements Operation<CreateCmsCmkCommand> {
         if (!isRunnable) {
             logger.warn("CMS config does not exist, please use 'create-cms-config' command first.");
         }
+
+        try {
+            final Properties cmsConfigProperties = configStore.getAllExistingCmsEnvProperties();
+            // additional argument validation
+            validateRegionsArg(command);
+            validateRotateArg(command, cmsConfigProperties);
+        } catch (ParameterException e) {
+            return false;
+        }
+
 
         return isRunnable;
     }


### PR DESCRIPTION
Do validation in isRunnable rather than run, so it plays nicer with composite commands.

As it is, it will throw a Runtime exception if you try to run the command again without the rotate flag, but it would be nicer if it logged the message and returned false for is runnable so it can be skipped.