### PR TITLE
enable rotation for non-tty environments and with manual option params

### DIFF
--- a/src/main/java/com/nike/cerberus/cli/ArgsBuilder.java
+++ b/src/main/java/com/nike/cerberus/cli/ArgsBuilder.java
@@ -52,6 +52,33 @@ public class ArgsBuilder {
         return this;
     }
 
+    /**
+     * Adds an argument option to the args list using the supplied value unless passed args contains the option and a value.
+     * @param optionKey The option to add to the args
+     * @param optionValue The option value to use if passed args doesn't already contain the option key and value
+     * @param passedArgs The passed args from the user
+     *
+     * @return The builder
+     */
+    public ArgsBuilder addOptionUsingPassedArgIfPresent(String optionKey, String optionValue, String [] passedArgs) {
+        int index = -1;
+        for (int i = 0; i < passedArgs.length; i++) {
+            if (optionKey.equals(passedArgs[i])) {
+                index = i;
+                break;
+            }
+        }
+
+        args.add(optionKey);
+        if (index > -1 && index < passedArgs.length - 2) {
+            args.add(passedArgs[index + 1]);
+        } else {
+            args.add(optionValue);
+        }
+
+        return this;
+    }
+
     public List<String> build() {
         return args;
     }

--- a/src/main/java/com/nike/cerberus/command/composite/GenerateAndRotateCertificatesCommand.java
+++ b/src/main/java/com/nike/cerberus/command/composite/GenerateAndRotateCertificatesCommand.java
@@ -14,26 +14,27 @@
  * limitations under the License.
  */
 
-package com.nike.cerberus.command.core;
+package com.nike.cerberus.command.composite;
 
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
+import com.nike.cerberus.command.core.GenerateCertificateFilesCommandParametersDelegate;
 import com.nike.cerberus.operation.Operation;
-import com.nike.cerberus.operation.core.GenerateCertificateFilesOperation;
+import com.nike.cerberus.operation.composite.GenerateAndRotateCertificatesOperation;
 
-import static com.nike.cerberus.command.core.GenerateCertificateFilesCommand.COMMAND_DESCRIPTION;
-import static com.nike.cerberus.command.core.GenerateCertificateFilesCommand.COMMAND_NAME;
+import static com.nike.cerberus.command.composite.GenerateAndRotateCertificatesCommand.COMMAND_NAME;
 
 @Parameters(
-        commandNames = COMMAND_NAME,
-        commandDescription = COMMAND_DESCRIPTION
+        commandNames = {
+                COMMAND_NAME
+        },
+        commandDescription = "Generates certificates with an ACME certificate provider and performs the necessary " +
+                "steps to rotate the certificates used by the ALB and CMS"
 )
-public class GenerateCertificateFilesCommand implements Command {
+public class GenerateAndRotateCertificatesCommand implements Command {
 
-    public static final String COMMAND_NAME = "generate-certificate-files";
-    public static final String COMMAND_DESCRIPTION = "Generates the TLS certificates needed to enable https " +
-            "through out the system, using an ACME provider such as LetsEncrypt";
+    public static final String COMMAND_NAME = "generate-and-rotate-certificates";
 
     @ParametersDelegate
     private GenerateCertificateFilesCommandParametersDelegate generateCertificateFilesCommandParametersDelegate =
@@ -50,6 +51,6 @@ public class GenerateCertificateFilesCommand implements Command {
 
     @Override
     public Class<? extends Operation<?>> getOperationClass() {
-        return GenerateCertificateFilesOperation.class;
+        return GenerateAndRotateCertificatesOperation.class;
     }
 }

--- a/src/main/java/com/nike/cerberus/command/composite/RotateCertificatesCommand.java
+++ b/src/main/java/com/nike/cerberus/command/composite/RotateCertificatesCommand.java
@@ -17,7 +17,9 @@
 package com.nike.cerberus.command.composite;
 
 import com.beust.jcommander.Parameters;
+import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
+import com.nike.cerberus.command.core.UploadCertificateFilesCommandParametersDelegate;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.composite.RotateCertificatesOperation;
 
@@ -31,9 +33,15 @@ import static com.nike.cerberus.command.composite.RotateCertificatesCommand.COMM
 public class RotateCertificatesCommand implements Command {
 
     public static final String COMMAND_NAME = "rotate-certificates";
-    public static final String COMMAND_DESCRIPTION = "Rotates the certificates used by the ALB and CMS. " +
-            "Generates new certs optionally, uploads the certs to IAM and S3, updating the ALB to use them, " +
-            "generates new cms config, followed by a rolling reboot of CMS finalized by the deletion the old certificates.";
+    public static final String COMMAND_DESCRIPTION = "Rotates the certificates used by the ALB and CMS.";
+
+    @ParametersDelegate
+    private UploadCertificateFilesCommandParametersDelegate uploadCertificateFilesCommandParametersDelegate
+            = new UploadCertificateFilesCommandParametersDelegate();
+
+    public UploadCertificateFilesCommandParametersDelegate getUploadCertificateFilesCommandParametersDelegate() {
+        return uploadCertificateFilesCommandParametersDelegate;
+    }
 
     @Override
     public String getCommandName() {

--- a/src/main/java/com/nike/cerberus/command/core/GenerateCertificateFilesCommandParametersDelegate.java
+++ b/src/main/java/com/nike/cerberus/command/core/GenerateCertificateFilesCommandParametersDelegate.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2017 Nike, Inc. 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+ * See the License for the specific language governing permissions and 
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.command.core;
+
+import com.beust.jcommander.Parameter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GenerateCertificateFilesCommandParametersDelegate {
+    
+    public static final String BASE_DOMAIN_LONG_ARG = "--base-domain";
+    public static final String EDGE_DOMAIN_NAME_OVERRIDE_LONG_ARG = "--edge-domain-name-override";
+    public static final String ORIGIN_DOMAIN_NAME_OVERRIDE_LONG_ARG = "--origin-domain-name-override";
+    public static final String LOAD_BALANCER_DOMAIN_NAME_OVERRIDE_LONG_ARG = "--load-balancer-domain-name-override";
+    public static final String HOSTED_ZONE_ID_LONG_ARG = "--hosted-zone-id";
+    public static final String SUBJECT_ALT_NAME_LONG_ARG = "--subject-alternative-name";
+    public static final String ENABLE_LE_CERTFIX_LONG_ARG = "--enable-letsecrypt-certfix";
+    public static final String CERT_FOLDER_LONG_ARG = "--local-certificate-directory";
+    public static final String ACME_API_LONG_ARG = "--acme-api-url";
+    public static final String CONTACT_EMAIL_LONG_ARG = "--contact-email";
+    public static final String NO_TTY_LONG_ARG = "--no-tty";
+    public static final String ACCEPT_ACME_TOS = "--no-tty-force-acme-tos-accept";
+
+    public static final String LETS_ENCRYPT_ACME_API_URI = "acme://letsencrypt.org";
+
+    @Parameter(
+            names = {
+                    BASE_DOMAIN_LONG_ARG
+            },
+            description = "The base domain for the environment that this command will use to generate the following " +
+                    "subject name {env}.{base-domain} and with the following subject alternative name {env}.{region}.{base-domain}\n" +
+                    "ex: cerberus -e demo -r us-west-2 generate-certificates --base-domain cerberus.example would make a cert for demo.cerberus.example " +
+                    "with a sans of demo.us-west-2.cerberus.example so that we can create a CNAME record for " +
+                    "demo.cerberus.example that will point to an ALB in us-west-2 with a CNAME record of " +
+                    "demo.us-west-2.cerberus.example and the cert will be valid for both"
+    )
+    private String baseDomainName;
+    
+    @Parameter(
+            names = {
+                    EDGE_DOMAIN_NAME_OVERRIDE_LONG_ARG
+            },
+            description = "This command uses {environment}.{base-domain} as the common name, override it with this option"
+    )
+    private String edgeDomainNameOverride;
+    
+    @Parameter(
+            names = {
+                    ORIGIN_DOMAIN_NAME_OVERRIDE_LONG_ARG
+            },
+            description = "origin domain name defaults to origin.{environment-name}.{base-domain}, " +
+                    "this command automatically creates a subject alternate name for this, override it with this option"
+    )
+    private String originDomainNameOverride;
+    
+    @Parameter(
+            names = {
+                    LOAD_BALANCER_DOMAIN_NAME_OVERRIDE_LONG_ARG
+            },
+            description = "the load balancer domain name defaults to {environment-name}.{primary-primaryRegion}.{base-domain}, " +
+                    "this command automatically creates a subject alternate name for this, override it with this option"
+    )
+    private String loadBalancerDomainNameOverride;
+    
+    @Parameter(
+            names = {
+                    HOSTED_ZONE_ID_LONG_ARG
+            },
+            description = "The AWS Route 53 hosted zone id that is configured to create records for the base domain",
+            required = true
+    )
+    private String hostedZoneId;
+    
+    @Parameter(
+            names = {
+                    SUBJECT_ALT_NAME_LONG_ARG
+            },
+            description = "Alternative subject names, this should be any additional cnames that need to be secured. such as "
+    )
+    private List<String> subjectAlternativeNames = new ArrayList<String>();
+
+    @Parameter(
+            names = {
+                    ENABLE_LE_CERTFIX_LONG_ARG
+            },
+            description = "This command uses the acme4j client to communicate with the ACME server, " +
+                    "it supports uses a hardcoded letsencrypt cert to get around ssl errors, you can use this " +
+                    "flag if your truststore is not configured to trust LE certificates, which can be found " +
+                    " here: https://letsencrypt.org/certificates/"
+    )
+    private boolean enableLetsEncryptCertfix = false;
+
+    @Parameter(
+            names = {
+                    CERT_FOLDER_LONG_ARG
+            },
+            description = "A local writable folder to store the generated key and cert files",
+            required = true
+    )
+    private String certDir;
+    
+    @Parameter(
+            names = {
+                    ACME_API_LONG_ARG
+            },
+            description = "The ACME provider API URL to use, e.g. Let's Encrypt: " + LETS_ENCRYPT_ACME_API_URI,
+            required = true
+    )
+    private String acmeApiUrl;
+    
+    @Parameter(
+            names = {
+                    CONTACT_EMAIL_LONG_ARG
+            },
+            description = "The email contact to use when creating the certificates",
+            required = true
+    )
+    private String contactEmail;
+
+    @Parameter(
+            names = {
+                    NO_TTY_LONG_ARG
+            },
+            description = "Flag to supply when running command in an environment without TTY, such as a build job"
+    )
+    private boolean tty = false;
+
+    @Parameter(
+            names = {
+                    ACCEPT_ACME_TOS
+            },
+            description = "If supplying --no-tty and creating a new ACME account you must go read the TOS and supply " +
+                    "this flag to indicate that you accept the TOS"
+    )
+    private boolean autoAcceptAcmeTos = false;
+
+    public String getBaseDomainName() {
+        return baseDomainName;
+    }
+
+    public String getEdgeDomainNameOverride() {
+        return edgeDomainNameOverride;
+    }
+
+    public String getOriginDomainNameOverride() {
+        return originDomainNameOverride;
+    }
+
+    public String getLoadBalancerDomainNameOverride() {
+        return loadBalancerDomainNameOverride;
+    }
+
+    public String getHostedZoneId() {
+        return hostedZoneId;
+    }
+
+    public List<String> getSubjectAlternativeNames() {
+        return subjectAlternativeNames;
+    }
+
+    public boolean enableLetsEncryptCertfix() {
+        return enableLetsEncryptCertfix;
+    }
+
+    public String getCertDir() {
+        return certDir;
+    }
+
+    public String getAcmeApiUrl() {
+        return acmeApiUrl;
+    }
+
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    public boolean isTty() {
+        return tty;
+    }
+
+    public boolean isAutoAcceptAcmeTos() {
+        return autoAcceptAcmeTos;
+    }
+}

--- a/src/main/java/com/nike/cerberus/command/core/GenerateCertificateFilesCommandParametersDelegate.java
+++ b/src/main/java/com/nike/cerberus/command/core/GenerateCertificateFilesCommandParametersDelegate.java
@@ -63,7 +63,7 @@ public class GenerateCertificateFilesCommandParametersDelegate {
             names = {
                     ORIGIN_DOMAIN_NAME_OVERRIDE_LONG_ARG
             },
-            description = "origin domain name defaults to origin.{environment-name}.{base-domain}, " +
+            description = "Origin domain name defaults to origin.{environment-name}.{base-domain}, " +
                     "this command automatically creates a subject alternate name for this, override it with this option"
     )
     private String originDomainNameOverride;
@@ -72,7 +72,7 @@ public class GenerateCertificateFilesCommandParametersDelegate {
             names = {
                     LOAD_BALANCER_DOMAIN_NAME_OVERRIDE_LONG_ARG
             },
-            description = "the load balancer domain name defaults to {environment-name}.{primary-primaryRegion}.{base-domain}, " +
+            description = "The load balancer domain name defaults to {environment-name}.{primary-primaryRegion}.{base-domain}, " +
                     "this command automatically creates a subject alternate name for this, override it with this option"
     )
     private String loadBalancerDomainNameOverride;
@@ -99,7 +99,7 @@ public class GenerateCertificateFilesCommandParametersDelegate {
                     ENABLE_LE_CERTFIX_LONG_ARG
             },
             description = "This command uses the acme4j client to communicate with the ACME server, " +
-                    "it supports uses a hardcoded letsencrypt cert to get around ssl errors, you can use this " +
+                    "it supports uses a hardcoded Let'sEncrypt cert to get around SSL errors, you can use this " +
                     "flag if your truststore is not configured to trust LE certificates, which can be found " +
                     " here: https://letsencrypt.org/certificates/"
     )

--- a/src/main/java/com/nike/cerberus/command/core/UploadCertificateFilesCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/UploadCertificateFilesCommand.java
@@ -16,14 +16,11 @@
 
 package com.nike.cerberus.command.core;
 
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.command.validator.UploadCertFilesPathValidator;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.core.UploadCertificatesFilesOperation;
-
-import java.nio.file.Path;
 
 import static com.nike.cerberus.command.core.UploadCertificateFilesCommand.COMMAND_NAME;
 
@@ -34,17 +31,13 @@ import static com.nike.cerberus.command.core.UploadCertificateFilesCommand.COMMA
 public class UploadCertificateFilesCommand implements Command {
 
     public static final String COMMAND_NAME = "upload-certificate-files";
-    public static final String CERT_PATH_LONG_ARG = "--cert-dir-path";
 
-    @Parameter(
-            names = {CERT_PATH_LONG_ARG},
-            required = true,
-            description = "Path to the directory that contains the certificate files.",
-            validateValueWith = UploadCertFilesPathValidator.class)
-    private Path certPath;
+    @ParametersDelegate
+    private final UploadCertificateFilesCommandParametersDelegate uploadCertificatesPathParametersDelegate =
+            new UploadCertificateFilesCommandParametersDelegate();
 
-    public Path getCertPath() {
-        return certPath;
+    public UploadCertificateFilesCommandParametersDelegate getUploadCertificatesPathParametersDelegate() {
+        return uploadCertificatesPathParametersDelegate;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/command/core/UploadCertificateFilesCommandParametersDelegate.java
+++ b/src/main/java/com/nike/cerberus/command/core/UploadCertificateFilesCommandParametersDelegate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.command.core;
+
+import com.beust.jcommander.Parameter;
+import com.nike.cerberus.command.validator.UploadCertFilesPathValidator;
+
+import java.nio.file.Path;
+
+public class UploadCertificateFilesCommandParametersDelegate {
+
+    public static final String CERT_PATH_LONG_ARG = "--cert-dir-path";
+
+    @Parameter(
+            names = {CERT_PATH_LONG_ARG},
+            required = true,
+            description = "Path to the directory that contains the certificate files.",
+            validateValueWith = UploadCertFilesPathValidator.class)
+    private Path certPath;
+
+    public Path getCertPath() {
+        return certPath;
+    }
+}

--- a/src/main/java/com/nike/cerberus/operation/composite/ChainableCommand.java
+++ b/src/main/java/com/nike/cerberus/operation/composite/ChainableCommand.java
@@ -79,6 +79,12 @@ public class ChainableCommand {
             return this;
         }
 
+        public Builder withOption(String key, String value) {
+            additionalArgs.add(key);
+            additionalArgs.add(value);
+            return this;
+        }
+
         public ChainableCommand build() {
             ChainableCommand chainableCommand = new ChainableCommand();
             chainableCommand.command = this.command;

--- a/src/main/java/com/nike/cerberus/operation/composite/GenerateAndRotateCertificatesOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/composite/GenerateAndRotateCertificatesOperation.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.operation.composite;
+
+import com.google.common.collect.Lists;
+import com.nike.cerberus.command.composite.GenerateAndRotateCertificatesCommand;
+import com.nike.cerberus.command.composite.RotateCertificatesCommand;
+import com.nike.cerberus.command.core.GenerateCertificateFilesCommand;
+import com.nike.cerberus.command.core.GenerateCertificateFilesCommandParametersDelegate;
+import com.nike.cerberus.domain.EnvironmentMetadata;
+import com.nike.cerberus.service.CloudFormationService;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static com.nike.cerberus.command.core.UploadCertificateFilesCommandParametersDelegate.CERT_PATH_LONG_ARG;
+import static com.nike.cerberus.command.core.GenerateCertificateFilesCommandParametersDelegate.*;
+
+public class GenerateAndRotateCertificatesOperation extends CompositeOperation<GenerateAndRotateCertificatesCommand> {
+
+    private final CloudFormationService cloudFormationService;
+    private final EnvironmentMetadata environmentMetadata;
+
+    @Inject
+    public GenerateAndRotateCertificatesOperation(CloudFormationService cloudFormationService,
+                                                  EnvironmentMetadata environmentMetadata) {
+
+        this.cloudFormationService = cloudFormationService;
+        this.environmentMetadata = environmentMetadata;
+    }
+
+
+    @Override
+    protected List<ChainableCommand> getCompositeCommandChain(GenerateAndRotateCertificatesCommand compositeCommand) {
+        GenerateCertificateFilesCommandParametersDelegate parameters = compositeCommand
+                .getGenerateCertificateFilesCommandParametersDelegate();
+
+        ChainableCommand.Builder generateCertificateFilesCommandBuilder = ChainableCommand.Builder.create()
+                .withCommand(new GenerateCertificateFilesCommand())
+                .withOption(
+                        BASE_DOMAIN_LONG_ARG,
+                        parameters.getBaseDomainName()
+                )
+                .withOption(
+                        EDGE_DOMAIN_NAME_OVERRIDE_LONG_ARG,
+                        parameters.getEdgeDomainNameOverride()
+                )
+                .withOption(
+                        ORIGIN_DOMAIN_NAME_OVERRIDE_LONG_ARG,
+                        parameters.getOriginDomainNameOverride()
+                )
+                .withOption(
+                        LOAD_BALANCER_DOMAIN_NAME_OVERRIDE_LONG_ARG,
+                        parameters.getLoadBalancerDomainNameOverride()
+                )
+                .withOption(
+                        HOSTED_ZONE_ID_LONG_ARG,
+                        parameters.getHostedZoneId()
+                )
+                .withOption(
+                        ENABLE_LE_CERTFIX_LONG_ARG,
+                        String.valueOf(parameters.enableLetsEncryptCertfix())
+                )
+                .withOption(
+                        CERT_FOLDER_LONG_ARG,
+                        parameters.getCertDir()
+                )
+                .withOption(
+                        ACME_API_LONG_ARG,
+                        parameters.getAcmeApiUrl()
+                )
+                .withOption(
+                        CONTACT_EMAIL_LONG_ARG,
+                        parameters.getContactEmail()
+                );
+
+                parameters.getSubjectAlternativeNames().forEach(name -> {
+                    generateCertificateFilesCommandBuilder.withOption(SUBJECT_ALT_NAME_LONG_ARG, name);
+                });
+
+        return Lists.newArrayList(
+                // Generate the Certificates
+                generateCertificateFilesCommandBuilder.build(),
+
+                // Rotate the certificate files
+                ChainableCommand.Builder.create().withCommand(new RotateCertificatesCommand())
+                        .withOption(
+                                CERT_PATH_LONG_ARG,
+                                parameters.getCertDir())
+                        .build()
+        );
+    }
+
+    @Override
+    public boolean isRunnable(GenerateAndRotateCertificatesCommand command) {
+        return RotateCertificatesOperation
+                .areRequiredStacksPresentToRotateCertificates(cloudFormationService, environmentMetadata);
+    }
+}

--- a/src/main/java/com/nike/cerberus/operation/composite/GenerateAndRotateCertificatesOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/composite/GenerateAndRotateCertificatesOperation.java
@@ -22,6 +22,7 @@ import com.nike.cerberus.command.composite.RotateCertificatesCommand;
 import com.nike.cerberus.command.core.GenerateCertificateFilesCommand;
 import com.nike.cerberus.command.core.GenerateCertificateFilesCommandParametersDelegate;
 import com.nike.cerberus.domain.EnvironmentMetadata;
+import com.nike.cerberus.domain.environment.Stack;
 import com.nike.cerberus.service.CloudFormationService;
 
 import javax.inject.Inject;
@@ -107,7 +108,19 @@ public class GenerateAndRotateCertificatesOperation extends CompositeOperation<G
 
     @Override
     public boolean isRunnable(GenerateAndRotateCertificatesCommand command) {
-        return RotateCertificatesOperation
-                .areRequiredStacksPresentToRotateCertificates(cloudFormationService, environmentMetadata);
+        boolean isRunnable = true;
+        String environmentName = environmentMetadata.getName();
+
+        if (! cloudFormationService.isStackPresent(Stack.LOAD_BALANCER.getFullName(environmentName))) {
+            log.error("The load-balancer stack must be present in order to rotate certificates");
+            isRunnable = false;
+        }
+
+        if (! cloudFormationService.isStackPresent(Stack.CMS.getFullName(environmentName))) {
+            log.error("The cms stack must be present to rotate certificates");
+            isRunnable = false;
+        }
+
+        return isRunnable;
     }
 }

--- a/src/main/java/com/nike/cerberus/operation/composite/RotateCertificatesOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/composite/RotateCertificatesOperation.java
@@ -76,22 +76,16 @@ public class RotateCertificatesOperation extends CompositeOperation<RotateCertif
 
     @Override
     public boolean isRunnable(RotateCertificatesCommand command) {
-        return areRequiredStacksPresentToRotateCertificates(cloudFormationService, environmentMetadata);
-    }
-
-    public static boolean areRequiredStacksPresentToRotateCertificates(CloudFormationService cloudFormationService,
-                                                                       EnvironmentMetadata environmentMetadata) {
-
         boolean isRunnable = true;
         String environmentName = environmentMetadata.getName();
 
         if (! cloudFormationService.isStackPresent(Stack.LOAD_BALANCER.getFullName(environmentName))) {
-            System.err.println("The load-balancer stack must be present in order to rotate certificates");
+            log.error("The load-balancer stack must be present in order to rotate certificates");
             isRunnable = false;
         }
 
         if (! cloudFormationService.isStackPresent(Stack.CMS.getFullName(environmentName))) {
-            System.err.println("The cms stack must be present to rotate certificates");
+            log.error("The cms stack must be present to rotate certificates");
             isRunnable = false;
         }
 

--- a/src/main/java/com/nike/cerberus/operation/core/UploadCertificatesFilesOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/UploadCertificatesFilesOperation.java
@@ -46,7 +46,7 @@ public class UploadCertificatesFilesOperation implements Operation<UploadCertifi
 
     @Override
     public void run(final UploadCertificateFilesCommand command) {
-        certificateService.uploadCertFiles(command.getCertPath().toFile());
+        certificateService.uploadCertFiles(command.getUploadCertificatesPathParametersDelegate().getCertPath().toFile());
     }
 
     @Override


### PR DESCRIPTION
- Created separate commands for generate-and-rotate-certificates and rotate-certificates to keep required options clean.
- Added flags to enable cert rotation in non-tty environments.
- Added manual flags so cert rotation can be done without YAML.