### PR TITLE
Feature/mr snapshot copier command

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -35,6 +35,7 @@ allprojects {
         compile group: 'com.amazonaws', name: 'aws-java-sdk-lambda', version: awsSDKVersion
         compile group: 'com.amazonaws', name: 'aws-java-sdk-route53', version: awsSDKVersion
         compile group: 'com.amazonaws', name: 'aws-java-sdk-elasticloadbalancingv2', version: awsSDKVersion
+        compile group: 'com.amazonaws', name: 'aws-java-sdk-rds', version: awsSDKVersion
 
         // https://mvnrepository.com/artifact/com.amazonaws/aws-encryption-sdk-java
         compile group: 'com.amazonaws', name: 'aws-encryption-sdk-java', version: '1.3.1'

--- a/src/main/java/com/nike/cerberus/cli/CerberusRunner.java
+++ b/src/main/java/com/nike/cerberus/cli/CerberusRunner.java
@@ -35,7 +35,8 @@ import com.nike.cerberus.command.composite.DeleteEnvironmentCommand;
 import com.nike.cerberus.command.composite.PrintAllStackInformationCommand;
 import com.nike.cerberus.command.composite.RotateCertificatesCommand;
 import com.nike.cerberus.command.core.InitializeEnvironmentCommand;
-import com.nike.cerberus.command.core.CreateDatabaseCommand;
+import com.nike.cerberus.command.rds.CopyRdsSnapshotsCommand;
+import com.nike.cerberus.command.rds.CreateDatabaseCommand;
 import com.nike.cerberus.command.core.CreateEdgeDomainRecordCommand;
 import com.nike.cerberus.command.core.CreateLoadBalancerCommand;
 import com.nike.cerberus.command.core.CreateRoute53Command;
@@ -193,6 +194,7 @@ public class CerberusRunner {
         registerCommand(new DeleteEnvironmentCommand());
         registerCommand(new RotateCertificatesCommand());
         registerCommand(new DeleteOldestCertificatesCommand());
+        registerCommand(new CopyRdsSnapshotsCommand());
     }
 
     /**

--- a/src/main/java/com/nike/cerberus/cli/EnvironmentConfigToArgsMapper.java
+++ b/src/main/java/com/nike/cerberus/cli/EnvironmentConfigToArgsMapper.java
@@ -23,7 +23,7 @@ import com.nike.cerberus.command.cms.UpdateCmsConfigCommand;
 import com.nike.cerberus.command.composite.GenerateAndRotateCertificatesCommand;
 import com.nike.cerberus.command.composite.RotateCertificatesCommand;
 import com.nike.cerberus.command.core.InitializeEnvironmentCommand;
-import com.nike.cerberus.command.core.CreateDatabaseCommand;
+import com.nike.cerberus.command.rds.CreateDatabaseCommand;
 import com.nike.cerberus.command.core.CreateEdgeDomainRecordCommand;
 import com.nike.cerberus.command.core.CreateLoadBalancerCommand;
 import com.nike.cerberus.command.core.CreateRoute53Command;

--- a/src/main/java/com/nike/cerberus/command/rds/CopyRdsSnapshotsCommand.java
+++ b/src/main/java/com/nike/cerberus/command/rds/CopyRdsSnapshotsCommand.java
@@ -26,7 +26,7 @@ import static com.nike.cerberus.command.rds.CopyRdsSnapshotsCommand.COMMAND_NAME
 
 @Parameters(
         commandNames = COMMAND_NAME,
-        commandDescription = "Copies rds cluster snapshots in the primary for this environment to the secondary regions"
+        commandDescription = "Copies RDS cluster snapshots in the primary for this environment to the secondary regions"
 )
 public class CopyRdsSnapshotsCommand implements Command {
 
@@ -36,7 +36,7 @@ public class CopyRdsSnapshotsCommand implements Command {
 
     @Parameter(
             names = DAYS_LONG_ARG,
-            description = "How old a rds cluster snapshot can be and still be considered for copying, defaults to 1 day"
+            description = "How old a RDS cluster snapshot can be and still be considered for copying, defaults to 1 day"
     )
     private long days = 1;
 

--- a/src/main/java/com/nike/cerberus/command/rds/CopyRdsSnapshotsCommand.java
+++ b/src/main/java/com/nike/cerberus/command/rds/CopyRdsSnapshotsCommand.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.command.rds;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.nike.cerberus.command.Command;
+import com.nike.cerberus.operation.Operation;
+import com.nike.cerberus.operation.rds.CopyRdsSnapshotsOperation;
+
+import static com.nike.cerberus.command.rds.CopyRdsSnapshotsCommand.COMMAND_NAME;
+
+@Parameters(
+        commandNames = COMMAND_NAME,
+        commandDescription = "Copies rds cluster snapshots in the primary for this environment to the secondary regions"
+)
+public class CopyRdsSnapshotsCommand implements Command {
+
+    public static final String COMMAND_NAME = "copy-rds-snapshots";
+
+    public static final String DAYS_LONG_ARG = "--days";
+
+    @Parameter(
+            names = DAYS_LONG_ARG,
+            description = "How old a rds cluster snapshot can be and still be considered for copying, defaults to 1 day"
+    )
+    private long days = 1;
+
+    public long getDays() {
+        return days;
+    }
+
+
+    @Override
+    public String getCommandName() {
+        return COMMAND_NAME;
+    }
+
+    @Override
+    public Class<? extends Operation<?>> getOperationClass() {
+        return CopyRdsSnapshotsOperation.class;
+    }
+}

--- a/src/main/java/com/nike/cerberus/command/rds/CreateDatabaseCommand.java
+++ b/src/main/java/com/nike/cerberus/command/rds/CreateDatabaseCommand.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.nike.cerberus.command.core;
+package com.nike.cerberus.command.rds;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -22,9 +22,9 @@ import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
 import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
 import com.nike.cerberus.operation.Operation;
-import com.nike.cerberus.operation.core.CreateDatabaseOperation;
+import com.nike.cerberus.operation.rds.CreateDatabaseOperation;
 
-import static com.nike.cerberus.command.core.CreateDatabaseCommand.COMMAND_NAME;
+import static com.nike.cerberus.command.rds.CreateDatabaseCommand.COMMAND_NAME;
 
 /**
  * Command to create the database for Cerberus.

--- a/src/main/java/com/nike/cerberus/operation/composite/CreateEnvironmentOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/composite/CreateEnvironmentOperation.java
@@ -21,7 +21,7 @@ import com.nike.cerberus.command.cms.CreateCmsClusterCommand;
 import com.nike.cerberus.command.cms.CreateCmsConfigCommand;
 import com.nike.cerberus.command.composite.CreateEnvironmentCommand;
 import com.nike.cerberus.command.core.InitializeEnvironmentCommand;
-import com.nike.cerberus.command.core.CreateDatabaseCommand;
+import com.nike.cerberus.command.rds.CreateDatabaseCommand;
 import com.nike.cerberus.command.core.CreateEdgeDomainRecordCommand;
 import com.nike.cerberus.command.core.CreateLoadBalancerCommand;
 import com.nike.cerberus.command.core.CreateRoute53Command;

--- a/src/main/java/com/nike/cerberus/operation/rds/CopyRdsSnapshotsOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/rds/CopyRdsSnapshotsOperation.java
@@ -106,7 +106,7 @@ public class CopyRdsSnapshotsOperation implements Operation<CopyRdsSnapshotsComm
      * @param toRegion The to region
      */
     private void copySnapshot(DBClusterSnapshot fromSnapshot, Regions fromRegion, Regions toRegion) {
-        AmazonRDS rds = AmazonRDSClient.builder().withRegion(toRegion).build();
+        AmazonRDS rds = amazonRDSClientFactory.getClient(toRegion);
         rds.copyDBClusterSnapshot(new CopyDBClusterSnapshotRequest()
                 .withCopyTags(true)
                 .withSourceDBClusterSnapshotIdentifier(fromSnapshot.getDBClusterSnapshotArn())

--- a/src/main/java/com/nike/cerberus/operation/rds/CopyRdsSnapshotsOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/rds/CopyRdsSnapshotsOperation.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.operation.rds;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.rds.AmazonRDS;
+import com.amazonaws.services.rds.AmazonRDSClient;
+import com.amazonaws.services.rds.model.CopyDBClusterSnapshotRequest;
+import com.amazonaws.services.rds.model.DBClusterSnapshot;
+import com.amazonaws.services.rds.model.DescribeDBClusterSnapshotsRequest;
+import com.amazonaws.services.rds.model.DescribeDBClusterSnapshotsResult;
+import com.amazonaws.services.rds.model.Tag;
+import com.nike.cerberus.command.rds.CopyRdsSnapshotsCommand;
+import com.nike.cerberus.operation.Operation;
+import com.nike.cerberus.service.AwsClientFactory;
+import com.nike.cerberus.store.ConfigStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.nike.cerberus.module.CerberusModule.ENV_NAME;
+
+/**
+ * Operation for CopyRdsSnapshotsCommand
+ *
+ * Copies rds cluster snapshots in the primary for this environment to the secondary regions
+ */
+public class CopyRdsSnapshotsOperation implements Operation<CopyRdsSnapshotsCommand> {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final ConfigStore configStore;
+    private final String environmentName;
+    private final AwsClientFactory<AmazonRDSClient> amazonRDSClientFactory;
+
+    @Inject
+    public CopyRdsSnapshotsOperation(ConfigStore configStore,
+                                     @Named(ENV_NAME) String environmentName,
+                                     AwsClientFactory<AmazonRDSClient> amazonRDSClientFactory) {
+
+        this.configStore = configStore;
+        this.environmentName = environmentName;
+        this.amazonRDSClientFactory = amazonRDSClientFactory;
+    }
+
+    @Override
+    public void run(CopyRdsSnapshotsCommand command) {
+        Regions primaryRegion = configStore.getPrimaryRegion();
+        List<DBClusterSnapshot> snapshotsInPrimaryRegion = getDbSnapshots(primaryRegion).stream()
+                .filter(dbSnapshot ->
+                        wasSnapshotGeneratedFromCmsCluster(dbSnapshot) && isSnapshotNewerThanGivenDays(dbSnapshot, command.getDays())
+                ).collect(Collectors.toList());
+
+        configStore.getConfigEnabledRegions().forEach(region -> {
+            if (region.equals(primaryRegion)) {
+                return;
+            }
+
+            List<DBClusterSnapshot> toRegionSnapshots = getDbSnapshots(region).stream()
+                    .filter(this::wasSnapshotGeneratedFromCmsCluster)
+                    .collect(Collectors.toList());
+
+            snapshotsInPrimaryRegion.forEach(fromSnapshot -> {
+                boolean needsCopying = toRegionSnapshots.stream().noneMatch(toSnapshot ->
+                        getIdentifier(fromSnapshot).equals(getIdentifier(toSnapshot)));
+                if (needsCopying) {
+                    log.info("Preparing to initiate copy of RDS DB Snapshot: {} located in region: {} to region: {}",
+                            fromSnapshot.getDBClusterSnapshotIdentifier(), primaryRegion, region);
+
+                    copySnapshot(fromSnapshot, primaryRegion, region);
+                } else {
+                    log.info("Snapshot: {} already copied to region: {}, skipping...", getIdentifier(fromSnapshot), region);
+                }
+            });
+        });
+        log.info("Finished issuing copy api calls to aws, it can take a long time for copies to finish.");
+    }
+
+    /**
+     * Copies a snapshot from one region to another
+     * @param fromSnapshot The snapshot that is getting copied
+     * @param fromRegion The from region
+     * @param toRegion The to region
+     */
+    private void copySnapshot(DBClusterSnapshot fromSnapshot, Regions fromRegion, Regions toRegion) {
+        AmazonRDS rds = AmazonRDSClient.builder().withRegion(toRegion).build();
+        rds.copyDBClusterSnapshot(new CopyDBClusterSnapshotRequest()
+                .withCopyTags(true)
+                .withSourceDBClusterSnapshotIdentifier(fromSnapshot.getDBClusterSnapshotArn())
+                .withTargetDBClusterSnapshotIdentifier(getIdentifier(fromSnapshot))
+                .withSourceRegion(fromRegion.getName())
+                .withKmsKeyId(configStore.getEnvironmentData().getRegionData().get(toRegion).getConfigCmkArn().get())
+                .withTags(
+                        new Tag().withKey("created-by").withValue("rds-snapshot-cross-region-duplicator")
+                )
+        );
+    }
+
+    /**
+     * Strips the rds: that aws prepends to automatic snapshots
+     * @param dbSnapshot the snapshot
+     * @return a string that can be used to identify automatic and manual copies rds:foo will return foo
+     */
+    protected String getIdentifier(DBClusterSnapshot dbSnapshot) {
+        return dbSnapshot.getDBClusterSnapshotIdentifier().replace("rds:", "");
+    }
+
+    /**
+     * @return True if the snapshot was created for the cms database cluster for this environment
+     */
+    protected boolean wasSnapshotGeneratedFromCmsCluster(DBClusterSnapshot dbSnapshot) {
+        String identifier = getIdentifier(dbSnapshot);
+        return identifier.startsWith(environmentName) && identifier.contains("cmsdatabasecluster");
+    }
+
+    /**
+     * @param dbSnapshot The snapshot under question
+     * @param days How many days to compare to
+     * @return True if the snapshot under question is newer than the days passed in
+     */
+    protected boolean isSnapshotNewerThanGivenDays(DBClusterSnapshot dbSnapshot, long days) {
+        return ZonedDateTime.ofInstant(dbSnapshot.getSnapshotCreateTime().toInstant(), ZoneId.of("UTC"))
+                .isAfter(Instant.now().atZone(ZoneId.of("UTC")).minus(days, ChronoUnit.DAYS));
+    }
+
+    /**
+     * @return All the RDS Cluster Snapshots for a region
+     */
+    protected List<DBClusterSnapshot> getDbSnapshots(Regions region) {
+        AmazonRDS rds = amazonRDSClientFactory.getClient(region);
+        List<DBClusterSnapshot> cmsDatabaseClusterSnapshots = new LinkedList<>();
+        String next = null;
+        do {
+            DescribeDBClusterSnapshotsRequest req = new DescribeDBClusterSnapshotsRequest();
+
+            if (next != null) {
+                req.withMarker(next);
+            }
+
+            DescribeDBClusterSnapshotsResult res = rds.describeDBClusterSnapshots(req);
+
+            cmsDatabaseClusterSnapshots.addAll(res.getDBClusterSnapshots());
+            next = res.getMarker();
+        } while (next != null);
+
+        return cmsDatabaseClusterSnapshots;
+    }
+
+    @Override
+    public boolean isRunnable(CopyRdsSnapshotsCommand command) {
+        return true;
+    }
+}

--- a/src/main/java/com/nike/cerberus/operation/rds/CopyRdsSnapshotsOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/rds/CopyRdsSnapshotsOperation.java
@@ -114,7 +114,7 @@ public class CopyRdsSnapshotsOperation implements Operation<CopyRdsSnapshotsComm
                 .withSourceRegion(fromRegion.getName())
                 .withKmsKeyId(configStore.getEnvironmentData().getRegionData().get(toRegion).getConfigCmkArn().get())
                 .withTags(
-                        new Tag().withKey("created-by").withValue("rds-snapshot-cross-region-duplicator")
+                        new Tag().withKey("created_by").withValue("cerberus_cli")
                 )
         );
     }

--- a/src/main/java/com/nike/cerberus/operation/rds/CreateDatabaseOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/rds/CreateDatabaseOperation.java
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package com.nike.cerberus.operation.core;
+package com.nike.cerberus.operation.rds;
 
 import com.amazonaws.regions.Regions;
-import com.nike.cerberus.command.core.CreateDatabaseCommand;
-import com.nike.cerberus.domain.cloudformation.DatabaseOutputs;
+import com.nike.cerberus.command.rds.CreateDatabaseCommand;
 import com.nike.cerberus.domain.cloudformation.DatabaseParameters;
 import com.nike.cerberus.domain.cloudformation.VpcOutputs;
 import com.nike.cerberus.domain.cloudformation.VpcParameters;

--- a/src/test/java/com/nike/cerberus/operation/rds/CopyRdsSnapshotsOperationTest.java
+++ b/src/test/java/com/nike/cerberus/operation/rds/CopyRdsSnapshotsOperationTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2017 Nike, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nike.cerberus.operation.rds;
+
+import com.amazonaws.services.rds.AmazonRDSClient;
+import com.amazonaws.services.rds.model.DBClusterSnapshot;
+import com.nike.cerberus.service.AwsClientFactory;
+import com.nike.cerberus.store.ConfigStore;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CopyRdsSnapshotsOperationTest {
+
+    @Mock
+    private ConfigStore configStore;
+
+    private final static String envName = "test";
+
+    @Mock
+    private AwsClientFactory<AmazonRDSClient> clientFactory;
+
+    private CopyRdsSnapshotsOperation operation;
+
+    @Before
+    public void before() {
+        operation = new CopyRdsSnapshotsOperation(configStore, envName, clientFactory);
+    }
+
+    @Test
+    public void test_that_wasSnapshotGeneratedFromCmsCluster_returns_true_if_id_matches() {
+        boolean actual = operation.wasSnapshotGeneratedFromCmsCluster(new DBClusterSnapshot()
+                .withDBClusterSnapshotIdentifier("rds:test-cerberus-database-cmsdatabasecluster-jns1lasdf9d-2017-12-12-18-07"));
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void test_that_wasSnapshotGeneratedFromCmsCluster_returns_false_for_a_different_env() {
+        boolean actual = operation.wasSnapshotGeneratedFromCmsCluster(new DBClusterSnapshot()
+                .withDBClusterSnapshotIdentifier("rds:dev-cerberus-database-cmsdatabasecluster-jns1lasdf9d-2017-12-12-18-07"));
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void test_that_wasSnapshotGeneratedFromCmsCluster_returns_false_if_id_does_not_matche() {
+        boolean actual = operation.wasSnapshotGeneratedFromCmsCluster(new DBClusterSnapshot()
+                .withDBClusterSnapshotIdentifier("rds:some-other-db-cluster-jns1lasdf9d-2017-12-12-18-07"));
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void test_that_isSnapshotNewerThan24Hours_returns_true_if_snapshot_is_newer_than_24h() {
+        DBClusterSnapshot ss = new DBClusterSnapshot().withSnapshotCreateTime(Date.from(Instant.now().atZone(ZoneId.of("UTC")).toInstant()));
+
+        boolean actual = operation.isSnapshotNewerThanGivenDays(ss, 1);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void test_that_isSnapshotNewerThan24Hours_returns_false_if_snapshot_is_older_than_24h() {
+        DBClusterSnapshot ss = new DBClusterSnapshot().withSnapshotCreateTime(Date.from(Instant.now().atZone(ZoneId.of("UTC"))
+                .minus(1, ChronoUnit.WEEKS).toInstant()));
+
+        boolean actual = operation.isSnapshotNewerThanGivenDays(ss, 1);
+
+        assertFalse(actual);
+    }
+
+}

--- a/src/test/java/com/nike/cerberus/operation/rds/CopyRdsSnapshotsOperationTest.java
+++ b/src/test/java/com/nike/cerberus/operation/rds/CopyRdsSnapshotsOperationTest.java
@@ -46,7 +46,7 @@ public class CopyRdsSnapshotsOperationTest {
 
     @Before
     public void before() {
-        operation = new CopyRdsSnapshotsOperation(configStore, envName, clientFactory);
+        operation = new CopyRdsSnapshotsOperation(configStore, envName, clientFactory, cloudFormationService);
     }
 
     @Test


### PR DESCRIPTION
- Added command that will enable copying of RDS Cluster Snapshots from the primary region to the secondary regions.

Please note that this command *DOES NOT* do any clean up of old snapshots, we can create another command for that like we have for cleaning up old certificates.