### PR TITLE
Removes the AWS WAF XSS rule

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@
 
 group=com.nike
 artifactId=cerberus-lifecycle-cli
-version=4.6.2
+version=4.6.3

--- a/src/main/resources/cloudformation/web-app-firewall.yaml
+++ b/src/main/resources/cloudformation/web-app-firewall.yaml
@@ -47,6 +47,14 @@ Resources:
             Type: BLOCK
           Priority: 5
           RuleId: !Ref 'WAFAutoBlockRule'
+        - Action:
+            Type: ALLOW
+          Priority: 6
+          RuleId: !Ref 'CerberusSecretAndSecureFileRule'
+        - Action:
+            Type: BLOCK
+          Priority: 7
+          RuleId: !Ref 'CerberusWafXssRule'
     Type: AWS::WAFRegional::WebACL
   CerberusWebACLAssociation:
     Type: "AWS::WAFRegional::WebACLAssociation"
@@ -96,6 +104,53 @@ Resources:
         - DataId: !Ref 'CerberusWafSqlInjectionMatchSet'
           Negated: 'false'
           Type: SqlInjectionMatch
+    Type: AWS::WAFRegional::Rule
+  CerberusWafXssMatchSet:
+    Properties:
+      Name: CerberusWafXssMatchSet
+      XssMatchTuples:
+        - FieldToMatch:
+            Type: URI
+          TextTransformation: NONE
+        - FieldToMatch:
+            Type: QUERY_STRING
+          TextTransformation: NONE
+        - FieldToMatch:
+            Type: BODY
+          TextTransformation: NONE
+    Type: AWS::WAFRegional::XssMatchSet
+  CerberusWafXssRule:
+    Properties:
+      MetricName: CerberusWafXss
+      Name: CerberusWafXssRule
+      Predicates:
+        - DataId: !Ref 'CerberusWafXssMatchSet'
+          Negated: 'false'
+          Type: XssMatch
+    Type: AWS::WAFRegional::Rule
+  CerberusSecretAndSecureFileMatchSet:
+    Properties:
+      Name: CerberusSecretAndSecureFileMatchSet
+      ByteMatchTuples:
+        - FieldToMatch:
+            Type: URI
+          TargetString: /secret/
+          TextTransformation: "NONE"
+          PositionalConstraint: "CONTAINS"
+        - FieldToMatch:
+            Type: URI
+          TargetString: /secure-file/
+          TextTransformation: "NONE"
+          PositionalConstraint: "CONTAINS"
+    Type: AWS::WAFRegional::ByteMatchSet
+  CerberusSecretAndSecureFileRule:
+    Properties:
+      MetricName: CerberusSecretAndSecureFile
+      Name: CerberusSecretAndSecureFileRule
+      Predicates:
+        - DataId: !Ref 'CerberusSecretAndSecureFileMatchSet'
+          Negated: 'false'
+          Type: ByteMatch
     Type: AWS::WAFRegional::Rule
   WAFAutoBlockRule:
     DependsOn: WAFAutoBlockSet

--- a/src/main/resources/cloudformation/web-app-firewall.yaml
+++ b/src/main/resources/cloudformation/web-app-firewall.yaml
@@ -36,20 +36,16 @@ Resources:
           Priority: 2
           RuleId: !Ref 'CerberusWafSqlInjectionRule'
         - Action:
-            Type: BLOCK
-          Priority: 3
-          RuleId: !Ref 'CerberusWafXssRule'
-        - Action:
             Type: ALLOW
-          Priority: 4
+          Priority: 3
           RuleId: !Ref 'WAFWhiteListRule'
         - Action:
             Type: BLOCK
-          Priority: 5
+          Priority: 4
           RuleId: !Ref 'WAFManualBlockRule'
         - Action:
             Type: BLOCK
-          Priority: 6
+          Priority: 5
           RuleId: !Ref 'WAFAutoBlockRule'
     Type: AWS::WAFRegional::WebACL
   CerberusWebACLAssociation:
@@ -100,29 +96,6 @@ Resources:
         - DataId: !Ref 'CerberusWafSqlInjectionMatchSet'
           Negated: 'false'
           Type: SqlInjectionMatch
-    Type: AWS::WAFRegional::Rule
-  CerberusWafXssMatchSet:
-    Properties:
-      Name: CerberusWafXssMatchSet
-      XssMatchTuples:
-        - FieldToMatch:
-            Type: URI
-          TextTransformation: NONE
-        - FieldToMatch:
-            Type: QUERY_STRING
-          TextTransformation: NONE
-        - FieldToMatch:
-            Type: BODY
-          TextTransformation: NONE
-    Type: AWS::WAFRegional::XssMatchSet
-  CerberusWafXssRule:
-    Properties:
-      MetricName: CerberusWafXss
-      Name: CerberusWafXssRule
-      Predicates:
-        - DataId: !Ref 'CerberusWafXssMatchSet'
-          Negated: 'false'
-          Type: XssMatch
     Type: AWS::WAFRegional::Rule
   WAFAutoBlockRule:
     DependsOn: WAFAutoBlockSet


### PR DESCRIPTION
The XSS rule inadvertently blocks valid file and secret POST requests,
returning 403 Forbidden. Prevent this bug by removing the rule.

UPDATE:
Move the XSS rule to the end instead of removing it so we can still take advantage of some of its value.