### PR TITLE
Renamed Tag Parameters Delegate to CloudFormation Parameters Delegate

### DIFF
--- a/src/main/java/com/nike/cerberus/cli/EnvironmentConfigToArgsMapper.java
+++ b/src/main/java/com/nike/cerberus/cli/EnvironmentConfigToArgsMapper.java
@@ -38,7 +38,7 @@ import com.nike.cerberus.command.core.GenerateCertificateFilesCommandParametersD
 import com.nike.cerberus.command.certificates.UploadCertificateFilesCommand;
 import com.nike.cerberus.command.certificates.UploadCertificateFilesCommandParametersDelegate;
 import com.nike.cerberus.command.core.WhitelistCidrForVpcAccessCommand;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.domain.input.EnvironmentConfig;
 import com.nike.cerberus.domain.input.ManagementServiceInput;
 import com.nike.cerberus.domain.input.ManagementServiceRegionSpecificInput;
@@ -225,7 +225,7 @@ public class EnvironmentConfigToArgsMapper {
     private static List<String> getGlobalTags(EnvironmentConfig environmentConfig) {
         ArgsBuilder args = ArgsBuilder.create();
         environmentConfig.getGlobalTags().forEach((key, value) ->
-                args.addDynamicProperty(TagParametersDelegate.TAG_SHORT_ARG, key, value)
+                args.addDynamicProperty(CloudFormationParametersDelegate.TAG_SHORT_ARG, key, value)
         );
         return args.build();
     }

--- a/src/main/java/com/nike/cerberus/command/StackDelegate.java
+++ b/src/main/java/com/nike/cerberus/command/StackDelegate.java
@@ -19,7 +19,7 @@ package com.nike.cerberus.command;
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +44,7 @@ public class StackDelegate {
     private String keyPairName;
 
     @ParametersDelegate
-    private TagParametersDelegate tagParameters = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
     @DynamicParameter(names = PARAMETER_SHORT_ARG, description = "Dynamic parameters for overriding the values for specific parameters in the CloudFormation.")
     private Map<String, String> dynamicParameters = new HashMap<>();
@@ -61,8 +61,8 @@ public class StackDelegate {
         return keyPairName;
     }
 
-    public TagParametersDelegate getTagParameters() {
-        return tagParameters;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     public Map<String, String> getDynamicParameters() {

--- a/src/main/java/com/nike/cerberus/command/audit/CreateAuditLoggingStackCommand.java
+++ b/src/main/java/com/nike/cerberus/command/audit/CreateAuditLoggingStackCommand.java
@@ -4,7 +4,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.audit.CreateAuditStackOperation;
 
@@ -33,10 +33,10 @@ public class CreateAuditLoggingStackCommand implements Command {
     }
 
     @ParametersDelegate
-    private TagParametersDelegate tagsDelegate = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
-    public TagParametersDelegate getTagsDelegate() {
-        return tagsDelegate;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/command/composite/UpdateAllStackTagsCommand.java
+++ b/src/main/java/com/nike/cerberus/command/composite/UpdateAllStackTagsCommand.java
@@ -19,7 +19,7 @@ package com.nike.cerberus.command.composite;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.composite.UpdateAllStackTagsOperation;
 
@@ -34,10 +34,10 @@ public class UpdateAllStackTagsCommand implements Command {
     public static final String COMMAND_NAME = "update-all-stack-tags";
 
     @ParametersDelegate
-    private TagParametersDelegate tagsDelegate = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
-    public TagParametersDelegate getTagsDelegate() {
-        return tagsDelegate;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/command/core/CreateLoadBalancerCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/CreateLoadBalancerCommand.java
@@ -20,7 +20,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.core.CreateLoadBalancerOperation;
 
@@ -38,10 +38,10 @@ public class CreateLoadBalancerCommand implements Command {
     public static final String LOAD_BALANCER_SSL_POLICY_OVERRIDE_LONG_ARG = "--ssl-policy-override";
 
     @ParametersDelegate
-    private TagParametersDelegate tagsDelegate = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
-    public TagParametersDelegate getTagsDelegate() {
-        return tagsDelegate;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     @Parameter(

--- a/src/main/java/com/nike/cerberus/command/core/CreateRoute53Command.java
+++ b/src/main/java/com/nike/cerberus/command/core/CreateRoute53Command.java
@@ -20,7 +20,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.core.CreateRoute53Operation;
 
@@ -44,10 +44,10 @@ public class CreateRoute53Command implements Command {
     public static final String LOAD_BALANCER_DOMAIN_NAME_OVERRIDE = "--load-balancer-domain-name-override";
 
     @ParametersDelegate
-    private TagParametersDelegate tagsDelegate = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
-    public TagParametersDelegate getTagsDelegate() {
-        return tagsDelegate;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     @Parameter(names = BASE_DOMAIN_NAME_LONG_ARG,

--- a/src/main/java/com/nike/cerberus/command/core/CreateSecurityGroupsCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/CreateSecurityGroupsCommand.java
@@ -19,7 +19,7 @@ package com.nike.cerberus.command.core;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.core.CreateSecurityGroupsOperation;
 
@@ -35,10 +35,10 @@ public class CreateSecurityGroupsCommand implements Command {
     public static final String COMMAND_NAME = "create-security-groups";
 
     @ParametersDelegate
-    private TagParametersDelegate tagParameters = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
-    public TagParametersDelegate getTagParameters() {
-        return tagParameters;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/command/core/CreateVpcCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/CreateVpcCommand.java
@@ -19,7 +19,7 @@ package com.nike.cerberus.command.core;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.core.CreateVpcOperation;
 
@@ -35,10 +35,10 @@ public class CreateVpcCommand implements Command {
     public static final String COMMAND_NAME = "create-vpc";
 
     @ParametersDelegate
-    private TagParametersDelegate tagsDelegate = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
-    public TagParametersDelegate getTagsDelegate() {
-        return tagsDelegate;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/command/core/CreateWafCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/CreateWafCommand.java
@@ -19,7 +19,7 @@ package com.nike.cerberus.command.core;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.core.CreateWafOperation;
 
@@ -35,10 +35,10 @@ public class CreateWafCommand implements Command {
     public static final String COMMAND_NAME = "create-waf";
 
     @ParametersDelegate
-    private TagParametersDelegate tagsDelegate = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
-    public TagParametersDelegate getTagsDelegate() {
-        return tagsDelegate;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/command/core/InitializeEnvironmentCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/InitializeEnvironmentCommand.java
@@ -20,7 +20,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.core.InitializeEnvironmentOperation;
 
@@ -69,7 +69,7 @@ public class InitializeEnvironmentCommand implements Command {
     private String primaryRegion;
 
     @ParametersDelegate
-    private TagParametersDelegate tagParameters = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
     public String getAdminRoleArn() {
         return adminRoleArn;
@@ -83,8 +83,8 @@ public class InitializeEnvironmentCommand implements Command {
         return primaryRegion;
     }
 
-    public TagParametersDelegate getTagsDelegate() {
-        return tagParameters;
+    public CloudFormationParametersDelegate getTagsDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/command/core/UpdateStackCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/UpdateStackCommand.java
@@ -21,7 +21,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.domain.environment.Stack;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.core.UpdateStackOperation;
@@ -49,10 +49,10 @@ public class UpdateStackCommand implements Command {
     private Stack stack;
 
     @ParametersDelegate
-    private TagParametersDelegate tagsDelegate = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
-    public TagParametersDelegate getTagsDelegate() {
-        return tagsDelegate;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     @Parameter(names = OVERWRITE_TEMPLATE_LONG_ARG,

--- a/src/main/java/com/nike/cerberus/command/core/UpdateStackTagsCommand.java
+++ b/src/main/java/com/nike/cerberus/command/core/UpdateStackTagsCommand.java
@@ -20,7 +20,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.domain.environment.Stack;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.core.UpdateStackTagsOperation;
@@ -43,14 +43,14 @@ public class UpdateStackTagsCommand implements Command {
     private Stack stack;
 
     @ParametersDelegate
-    private TagParametersDelegate tagsDelegate = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
     @Parameter(names = OVERWRITE_TAGS_LONG_ARG,
             description = "Flag for overwriting existing CloudFormation template")
     private boolean overwriteTags;
 
-    public TagParametersDelegate getTagsDelegate() {
-        return tagsDelegate;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     public Stack getStack() {

--- a/src/main/java/com/nike/cerberus/command/rds/CreateDatabaseCommand.java
+++ b/src/main/java/com/nike/cerberus/command/rds/CreateDatabaseCommand.java
@@ -20,7 +20,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
 import com.nike.cerberus.command.Command;
-import com.nike.cerberus.domain.cloudformation.TagParametersDelegate;
+import com.nike.cerberus.domain.cloudformation.CloudFormationParametersDelegate;
 import com.nike.cerberus.operation.Operation;
 import com.nike.cerberus.operation.rds.CreateDatabaseOperation;
 
@@ -40,10 +40,10 @@ public class CreateDatabaseCommand implements Command {
     public static final String RESTORE_FROM_SNAPSHOT = "--restore-from-snapshot-using-identifier";
 
     @ParametersDelegate
-    private TagParametersDelegate tagsDelegate = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
-    public TagParametersDelegate getTagsDelegate() {
-        return tagsDelegate;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
     @Parameter(names = INSTANCE_CLASS_LONG_ARG,

--- a/src/main/java/com/nike/cerberus/domain/cloudformation/CloudFormationParametersDelegate.java
+++ b/src/main/java/com/nike/cerberus/domain/cloudformation/CloudFormationParametersDelegate.java
@@ -20,12 +20,11 @@ import com.beust.jcommander.DynamicParameter;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * CloudFormation input parameters common to all Cerberus CloudFormation stacks.
  */
-public class TagParametersDelegate {
+public class CloudFormationParametersDelegate {
 
     public static final String TAG_LONG_ARG = "--TAG";
     public static final String TAG_SHORT_ARG = "-T";

--- a/src/main/java/com/nike/cerberus/domain/cloudformation/GatewayParameters.java
+++ b/src/main/java/com/nike/cerberus/domain/cloudformation/GatewayParameters.java
@@ -56,7 +56,7 @@ public class GatewayParameters implements LaunchConfigParameters {
     private LaunchConfigParametersDelegate launchConfigParameters = new LaunchConfigParametersDelegate();
 
     @JsonUnwrapped
-    private TagParametersDelegate tagParameters = new TagParametersDelegate();
+    private CloudFormationParametersDelegate cloudFormationParametersDelegate = new CloudFormationParametersDelegate();
 
     public String getVpcId() {
         return vpcId;
@@ -167,12 +167,12 @@ public class GatewayParameters implements LaunchConfigParameters {
         return this;
     }
 
-    public TagParametersDelegate getTagParameters() {
-        return tagParameters;
+    public CloudFormationParametersDelegate getCloudFormationParametersDelegate() {
+        return cloudFormationParametersDelegate;
     }
 
-    public GatewayParameters setTagParameters(TagParametersDelegate tagParameters) {
-        this.tagParameters = tagParameters;
+    public GatewayParameters setCloudFormationParametersDelegate(CloudFormationParametersDelegate cloudFormationParametersDelegate) {
+        this.cloudFormationParametersDelegate = cloudFormationParametersDelegate;
         return this;
     }
 

--- a/src/main/java/com/nike/cerberus/operation/audit/CreateAuditStackOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/audit/CreateAuditStackOperation.java
@@ -48,7 +48,7 @@ public class CreateAuditStackOperation implements Operation<CreateAuditLoggingSt
                 .setCmsIamRoleArn(configStore.getCmsIamRoleOutputs().getCmsIamRoleArn())
                 .setEnvironmentName(environmentName);
         Map<String, String> parameters = cloudFormationObjectMapper.convertValue(auditParameters);
-        cloudFormationService.createStackAndWait(primaryRegion, Stack.AUDIT, parameters, true, command.getTagsDelegate().getTags());
+        cloudFormationService.createStackAndWait(primaryRegion, Stack.AUDIT, parameters, true, command.getCloudFormationParametersDelegate().getTags());
     }
 
 

--- a/src/main/java/com/nike/cerberus/operation/cms/CreateCmsClusterOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/cms/CreateCmsClusterOperation.java
@@ -73,7 +73,7 @@ public class CreateCmsClusterOperation implements Operation<CreateCmsClusterComm
         VpcOutputs vpcOutputs = configStore.getVpcStackOutputs();
         List<CertificateInformation> certInfoListForStack = configStore.getCertificationInformationList();
 
-        Map<String, String> tags = command.getStackDelegate().getTagParameters().getTags();
+        Map<String, String> tags = command.getStackDelegate().getCloudFormationParametersDelegate().getTags();
 
         if (certInfoListForStack.isEmpty()) {
             throw new IllegalStateException("Certificate for cerberus environment has not been uploaded!");

--- a/src/main/java/com/nike/cerberus/operation/composite/UpdateAllStackTagsOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/composite/UpdateAllStackTagsOperation.java
@@ -42,7 +42,7 @@ public class UpdateAllStackTagsOperation extends CompositeOperation<UpdateAllSta
                             .withCommand(new UpdateStackTagsCommand())
                             .withAdditionalArg(UpdateStackTagsCommand.STACK_NAME_LONG_ARG)
                             .withAdditionalArg(stack.toString())
-                            .withAdditionalArg(compositeCommand.getTagsDelegate().getArgs())
+                            .withAdditionalArg(compositeCommand.getCloudFormationParametersDelegate().getArgs())
                             .build()
             );
         }

--- a/src/main/java/com/nike/cerberus/operation/core/CreateLoadBalancerOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/CreateLoadBalancerOperation.java
@@ -127,7 +127,7 @@ public class CreateLoadBalancerOperation implements Operation<CreateLoadBalancer
                 Stack.LOAD_BALANCER,
                 parameters,
                 true,
-                command.getTagsDelegate().getTags());
+                command.getCloudFormationParametersDelegate().getTags());
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/operation/core/CreateRoute53Operation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/CreateRoute53Operation.java
@@ -80,7 +80,7 @@ public class CreateRoute53Operation implements Operation<CreateRoute53Command> {
                 Stack.ROUTE53,
                 parameters,
                 true,
-                command.getTagsDelegate().getTags());
+                command.getCloudFormationParametersDelegate().getTags());
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/operation/core/CreateSecurityGroupsOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/CreateSecurityGroupsOperation.java
@@ -73,7 +73,7 @@ public class CreateSecurityGroupsOperation implements Operation<CreateSecurityGr
                 Stack.SECURITY_GROUPS,
                 parameters,
                 true,
-                command.getTagParameters().getTags());
+                command.getCloudFormationParametersDelegate().getTags());
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/operation/core/CreateVpcOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/CreateVpcOperation.java
@@ -84,7 +84,7 @@ public class CreateVpcOperation implements Operation<CreateVpcCommand> {
                 Stack.VPC,
                 parameters,
                 true,
-                command.getTagsDelegate().getTags());
+                command.getCloudFormationParametersDelegate().getTags());
     }
 
     @Override

--- a/src/main/java/com/nike/cerberus/operation/core/CreateWafOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/CreateWafOperation.java
@@ -72,7 +72,7 @@ public class CreateWafOperation implements Operation<CreateWafCommand> {
                 Stack.WAF,
                 parameters,
                 true,
-                command.getTagsDelegate().getTags()
+                command.getCloudFormationParametersDelegate().getTags()
         );
     }
 

--- a/src/main/java/com/nike/cerberus/operation/core/UpdateStackOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/UpdateStackOperation.java
@@ -64,7 +64,7 @@ public class UpdateStackOperation implements Operation<UpdateStackCommand> {
         String stackId = command.getStack().getFullName(environmentName);
 
         Map<String, String> parameters = cloudFormationService.getStackParameters(configStore.getPrimaryRegion(), stackId);
-        Map<String, String> tags = command.getTagsDelegate().getTags();
+        Map<String, String> tags = command.getCloudFormationParametersDelegate().getTags();
 
         // only some stacks need user data
         if (command.getStack().needsUserData()) {
@@ -100,7 +100,7 @@ public class UpdateStackOperation implements Operation<UpdateStackCommand> {
                     parameters,
                     true,
                     command.isOverwriteTemplate(),
-                    command.getTagsDelegate().getTags()
+                    command.getCloudFormationParametersDelegate().getTags()
             );
 
             logger.info("Update complete.");

--- a/src/main/java/com/nike/cerberus/operation/core/UpdateStackTagsOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/core/UpdateStackTagsOperation.java
@@ -58,7 +58,7 @@ public class UpdateStackTagsOperation implements Operation<UpdateStackTagsComman
     public void run(UpdateStackTagsCommand command) {
         String stackId = command.getStack().getFullName(environmentName);
         Map<String, String> parameters = cloudFormationService.getStackParameters(configStore.getPrimaryRegion(), stackId);
-        Map<String, String> tags = command.getTagsDelegate().getTags();
+        Map<String, String> tags = command.getCloudFormationParametersDelegate().getTags();
         if (!command.isOverwriteTags()){
             Map<String, String> existingTags = cloudFormationService.getStackTags(configStore.getPrimaryRegion(), stackId);
             existingTags.forEach((k, v) -> tags.merge(k, v, (o, n)->o));
@@ -78,7 +78,7 @@ public class UpdateStackTagsOperation implements Operation<UpdateStackTagsComman
                     parameters,
                     true,
                     false,
-                    command.getTagsDelegate().getTags()
+                    command.getCloudFormationParametersDelegate().getTags()
             );
 
             logger.info("Update complete.");

--- a/src/main/java/com/nike/cerberus/operation/rds/CreateDatabaseOperation.java
+++ b/src/main/java/com/nike/cerberus/operation/rds/CreateDatabaseOperation.java
@@ -96,7 +96,7 @@ public class CreateDatabaseOperation implements Operation<CreateDatabaseCommand>
                 Stack.DATABASE,
                 parameters,
                 true,
-                command.getTagsDelegate().getTags()
+                command.getCloudFormationParametersDelegate().getTags()
         );
     }
 
@@ -108,7 +108,7 @@ public class CreateDatabaseOperation implements Operation<CreateDatabaseCommand>
             isRunnable = false;
             logger.error("The security group stack must exist to create the the data base stack!");
         }
-        
+
         if (cloudFormationService.isStackPresent(configStore.getPrimaryRegion(), Stack.DATABASE.getFullName(environmentName))) {
             isRunnable = false;
             logger.error("The database stack already exists, use update-stack");


### PR DESCRIPTION
Renamed Tag Parameters Delegate to CloudFormation Parameters Delegate to better represent that it is generic params delegate for commands that wrap CloudFormation stacks.