### PR TITLE
feat: added ability to supply additional ARNs for audit log bucket perms

### DIFF
--- a/src/main/resources/cloudformation/audit.yaml
+++ b/src/main/resources/cloudformation/audit.yaml
@@ -10,9 +10,21 @@ Parameters:
   accountAdminArn:
     Description: The ARN for a IAM user, group or role that can create this stack.
     Type: String
+  additionalArns:
+    Description: (Optional) Additional Arns to let access the audit data
+    Type: CommaDelimitedList
+    Default: ""
   environmentName:
     Description: The Cerberus environment name.
     Type: String
+Conditions:
+  addtionalArnsWhereSupplied:
+    Fn::Not:
+      - Fn::Equals:
+          - Fn::Join:
+              - ""
+              - Ref: additionalArns
+          - ""
 Resources:
   CerberusAuditBucket:
     Properties:
@@ -29,17 +41,18 @@ Resources:
       Bucket: !Ref 'CerberusAuditBucket'
       PolicyDocument:
         Statement:
-          - Action:
+          - Sid: Allow-Bucket-Access-For-CMS
+            Action:
               - s3:*
             Effect: Allow
             Principal:
               AWS:
-                - !Ref 'cmsIamRoleArn'
+              - !Ref 'cmsIamRoleArn'
             Resource:
               - !Join ['', ['arn:aws:s3:::', !Ref 'CerberusAuditBucket']]
               - !Join ['', ['arn:aws:s3:::', !Ref 'CerberusAuditBucket', /*]]
-            Sid: Allow-Bucket-Access-For-CMS
-          - Action:
+          - Sid: Allow-Bucket-Access-For-Account-Admin-Arn
+            Action:
               - s3:*
             Effect: Allow
             Principal:
@@ -48,8 +61,17 @@ Resources:
             Resource:
               - !Join ['', ['arn:aws:s3:::', !Ref 'CerberusAuditBucket']]
               - !Join ['', ['arn:aws:s3:::', !Ref 'CerberusAuditBucket', /*]]
-            Sid: Allow-Bucket-Access-For-AuditLogAthenaIamRole
-          - Action:
+          - Sid: Allow-Bucket-Access-For-Additional-Arns
+            Action:
+              - s3:*
+            Effect: Allow
+            Principal:
+              AWS: !If [addtionalArnsWhereSupplied, !Ref additionalArns, [ !Ref 'accountAdminArn' ]] # hack, if no extra ARNs are supplied just repeat that admin arn
+            Resource:
+              - !Join ['', ['arn:aws:s3:::', !Ref 'CerberusAuditBucket']]
+              - !Join ['', ['arn:aws:s3:::', !Ref 'CerberusAuditBucket', /*]]
+          - Sid: Allow-Bucket-Access-For-AuditLogAthenaIamRole
+            Action:
               - s3:*
             Effect: Allow
             Principal:
@@ -58,7 +80,6 @@ Resources:
             Resource:
               - !Join ['', ['arn:aws:s3:::', !Ref 'CerberusAuditBucket']]
               - !Join ['', ['arn:aws:s3:::', !Ref 'CerberusAuditBucket', /*]]
-            Sid: Allow-Bucket-Access-For-AuditLogAthenaIamRole
         Version: '2012-10-17'
   AuditLogAthenaIamRole:
       Type: AWS::IAM::Role
@@ -109,6 +130,14 @@ Resources:
              Principal:
                AWS:
                  !Ref 'accountAdminArn'
+             Resource: '*'
+           - Sid: Allow-Additional-Arns
+             Action:
+               - kms:*
+             Effect: Allow
+             Principal:
+               AWS:
+                 !If [addtionalArnsWhereSupplied, !Ref additionalArns, [ !Ref 'accountAdminArn' ]] # hack, if no extra ARNs are supplied just repeat that admin arn
              Resource: '*'
            - Sid: Allow-AuditLogAthenaIamRole
              Action:


### PR DESCRIPTION
We need the ability to add additional arns.

This will allow us to have cron jobs on our CI/CD box to generate audit reports for various stake holders.