### PR TITLE
Reduce logging of stack traces that don't matter

### DIFF
--- a/src/main/resources/cerberus-lifecycle-cli.properties
+++ b/src/main/resources/cerberus-lifecycle-cli.properties
@@ -15,3 +15,5 @@
 #
 
 cli.version = @@RELEASE@@
+logging.level.com.amazonaws.util.EC2MetadataUtils=error
+logging.level.com.amazonaws.internal.InstanceMetadataServiceResourceFetcher=error


### PR DESCRIPTION
Avoids showing errors that are part of the normal resolution of the credentials provider chain. 